### PR TITLE
Feature/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Create an environment file to pass the default public token into the project.
 1. Create a new file, .env,  in the main directory (with the README.md file) 
 
 2. Add your decault public token to your .env 
-   '''sh
+   ```sh
    NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_default_public_token
-   '''
+   ```
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ Hello! Thanks for checking out Support SFUSD. We started this project in summer 
 [![Tailwind CSS][tailwind.js]][tailwind-url]
 [![HTML][html.js]][html-url]
 [![CSS][css.js]][css-url]
+[![Mapbox][mapbox.js]][mapbox-url]
+
+<br>
+
+# Mapbox 
+
+You need to sign up for Mapbox to run the project locally.   
+
+1. Goto https://www.mapbox.com and sign up  
+
+2. It will ask you for billing information, but it is pay as you go. You have 500 instances before you are charged. 
+
+3. Note the default public token you are given
+
+<br>  
+
+Create an environment file to pass the default public token into the project.  
+
+1. Create a new file, .env,  in the main directory (with the README.md file) 
+
+2. Add your decault public token to your .env 
+   '''sh
+   NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_default_public_token
+   '''
 
 <br>
 
@@ -54,4 +78,6 @@ To run this project locally, please perform the following steps:
 [tailwind.js]: https://img.shields.io/badge/Tailwind_CSS-38B2AC?style=for-the-badge&logo=tailwind-css&logoColor=white
 [tailwind-url]: https://tailwindcss.com/
 [next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
-[nextjs-url]: https://nextjs.org/
+[nextjs-url]: https://nextjs.org/ 
+[mapbox.js]: https://img.shields.io/badge/mapbox-purple
+[mapbox-url]: https://www.mapbox.com/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Hello! Thanks for checking out Support SFUSD. We started this project in summer 
 [![Tailwind CSS][tailwind.js]][tailwind-url]
 [![HTML][html.js]][html-url]
 [![CSS][css.js]][css-url]
-[![Mapbox][mapbox.js]][mapbox-url]
 
 <br>
 
@@ -81,5 +80,4 @@ To run this project locally, please perform the following steps:
 [tailwind-url]: https://tailwindcss.com/
 [next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
 [nextjs-url]: https://nextjs.org/ 
-[mapbox.js]: https://img.shields.io/badge/mapbox-purple
-[mapbox-url]: https://www.mapbox.com/
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To run this project locally, please perform the following steps:
 
 # Further Notes to help you out 
 
-Visit our [notion-url](Notion) for Engineers 
+Visit our [Notion](notion-url) for Engineers 
 
 <!-- References and Icons -->
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ You need to sign up for Mapbox to run the project locally.
 
 2. It will ask you for billing information, but it is pay as you go. You have 500 instances before you are charged. 
 
-3. Note the default public token you are given
+3. Note the default public token you are given  
 
-<br>  
+<br>
 
-Create an environment file to pass the default public token into the project.  
+# Environment File
+
+Create an environment file to pass your default public token from Mapbox
 
 1. Create a new file, .env,  in the main directory (with the README.md file) 
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ To run this project locally, please perform the following steps:
 
 <br>
 
-# Contact
+# Further Notes to help you out 
+
+Visit our [notion-url](Notion) for Engineers 
 
 <!-- References and Icons -->
 
@@ -80,4 +82,5 @@ To run this project locally, please perform the following steps:
 [tailwind-url]: https://tailwindcss.com/
 [next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
 [nextjs-url]: https://nextjs.org/ 
+[notion-url]: https://www.notion.so/Engineering-Start-5cddd23f2ab0494cba2edcc93764f27f?pvs=4
 


### PR DESCRIPTION
#28 Wiki for onboarding  

- added to Read Me instructions to allow new engineers to run repo and see where main is at   
- added to notion onboarding engineers instructions 
- notion and github reference each other