### PR TITLE
[Closes #35] Mapbox re-render fix

### DIFF
--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -16,6 +16,7 @@ const MapboxMap = ({ setSelectedSchool }: MapboxMapProps) => {
       console.error("Mapbox access token or container is not set!");
       return;
     }
+    if (mapRef.current) return
 
     mapboxgl.accessToken = accessToken;
     const map = new mapboxgl.Map({


### PR DESCRIPTION
- previously zooming in or clicking different schools would trigger a re-render of the map, map only renders on initialization