### PR TITLE
restore id="root" to fix mobile list header moving offscreen

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -11,8 +11,13 @@ function RootLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const { pathname } = router;
 
+  // NOTE: id="root" is currently needed by the JS view logic in `map.tsx`
+  // to complement the the Tailwind media-query driven classes in
+  // constraining the map height to the viewport for mobile
+
   return (
     <div
+      id="root"
       className={`${inter.className} flex flex-col px-0 md:px-4 ${pathname.includes("/map") ? "h-screen" : "h-auto"}`}
     >
       {pathname.includes("/profile") && (

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -37,6 +37,7 @@ const Map: React.FC<Props> = (props) => {
 
     // base new layout on isMap BEFORE it changes to the new value
     // (otherwise the h-screen appears to apply too late)
+    // FIXME: investigate how to do this in a more canonical NextJS/React way
     const root = document.getElementById("root");
     // toggle between map and list layout
     root?.classList.remove(isMap ? "h-screen" : "h-auto");


### PR DESCRIPTION
fixes header scrolling offscreen regression by adding `id="root"` back into code.

also adds comments about view logic that utilizes this id attribute

Closes #109.