### PR TITLE
add conditional link on school card image (for desktop)/add link around map card (for mobile)

### DIFF
--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -59,12 +59,24 @@ const SchoolCard: React.FC<SchoolCardProps> = ({
         className={`transition-max-height relative col-span-4 h-auto w-2/5 rounded-l-2xl bg-cover bg-center duration-[700ms] md:col-span-3 md:h-40 md:w-full md:rounded-b-lg
         md:rounded-t-2xl`}
       >
+        <Link
+          href={"/school?name=" + encodeURIComponent(school.name)}
+          className="hidden md:inline"
+        >
+          <Image
+            src={"/school_img/" + school.img}
+            alt={school.name}
+            width={1000}
+            height={500}
+            className="h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl"
+          />
+        </Link>
         <Image
           src={"/school_img/" + school.img}
           alt={school.name}
           width={1000}
           height={500}
-          className="h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl"
+          className="inline-block h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:hidden md:max-h-none md:rounded-b-lg md:rounded-t-2xl"
         />
       </div>
       <div className="flex h-full w-3/5 flex-col p-2 md:w-full md:p-4">

--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -4,16 +4,6 @@ import Image from "next/image";
 import Link from "next/link";
 import Tag from "./Tag";
 
-const SchoolImage = (props: any) => (
-  <Image
-    src={props.src}
-    alt={props.alt}
-    width={1000}
-    height={500}
-    className={`h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl ${props.className}`}
-  />
-);
-
 interface SchoolCardProps {
   school: School;
   className?: string;
@@ -50,6 +40,19 @@ const SchoolCard: React.FC<SchoolCardProps> = ({
   const ell = school.metrics.find(
     (metric) => metric.name == "English Language Learners",
   );
+
+  /* TODO: look into whether or not creating a `WithLink` component
+can simplify this somehow */
+  const SchoolImage = (props: any) => (
+    <Image
+      src={props.src}
+      alt={props.alt}
+      width={1000}
+      height={500}
+      className={`h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl ${props.className}`}
+    />
+  );
+
   return (
     <div
       className={`flex flex-row items-start justify-center rounded-[16px] bg-white shadow-lg md:max-w-[400px] md:flex-col ${className}`}

--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -4,6 +4,16 @@ import Image from "next/image";
 import Link from "next/link";
 import Tag from "./Tag";
 
+const SchoolImage = (props: any) => (
+  <Image
+    src={props.src}
+    alt={props.alt}
+    width={1000}
+    height={500}
+    className={`h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl ${props.className}`}
+  />
+);
+
 interface SchoolCardProps {
   school: School;
   className?: string;
@@ -63,20 +73,12 @@ const SchoolCard: React.FC<SchoolCardProps> = ({
           href={"/school?name=" + encodeURIComponent(school.name)}
           className="hidden md:inline"
         >
-          <Image
-            src={"/school_img/" + school.img}
-            alt={school.name}
-            width={1000}
-            height={500}
-            className="h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl"
-          />
+          <SchoolImage src={`/school_img/${school.img}`} alt={school.name} />
         </Link>
-        <Image
-          src={"/school_img/" + school.img}
+        <SchoolImage
+          src={`/school_img/${school.img}`}
           alt={school.name}
-          width={1000}
-          height={500}
-          className="inline-block h-40 max-h-[20vh] w-full rounded-l-2xl object-cover md:hidden md:max-h-none md:rounded-b-lg md:rounded-t-2xl"
+          className="inline-block md:hidden"
         />
       </div>
       <div className="flex h-full w-3/5 flex-col p-2 md:w-full md:p-4">

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -71,6 +71,16 @@ const Map: React.FC<Props> = (props) => {
     setSelectedSchool(selection.item);
   };
 
+  /* TODO: look into whether or not creating a `WithLink` component
+  can simplify this somehow */
+  const SelectedSchoolCard = (props: any) => (
+    <SchoolCard
+      school={props.school}
+      onClose={onClose}
+      className={`block ${props.className}`}
+    />
+  );
+
   useEffect(() => {
     if (isMap && window.innerWidth <= 768) {
       window.scrollTo({
@@ -101,11 +111,10 @@ const Map: React.FC<Props> = (props) => {
                     }
                     className="block md:hidden"
                   >
-                    <SchoolCard school={selectedSchool} onClose={onClose} />
+                    <SelectedSchoolCard school={selectedSchool} />
                   </Link>
-                  <SchoolCard
+                  <SelectedSchoolCard
                     school={selectedSchool}
-                    onClose={onClose}
                     className="hidden md:block"
                   />
                 </div>

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -95,7 +95,12 @@ const Map: React.FC<Props> = (props) => {
             {isMap ? (
               selectedSchool ? (
                 <div className="w-full md:w-auto">
-                  <Link href="#" className="block md:hidden">
+                  <Link
+                    href={
+                      "/school?name=" + encodeURIComponent(selectedSchool.name)
+                    }
+                    className="block md:hidden"
+                  >
                     <SchoolCard school={selectedSchool} onClose={onClose} />
                   </Link>
                   <SchoolCard


### PR DESCRIPTION
Add conditional link on Map's school card image for desktop web only.

Addresses #115 for desktop Map cards.

---

Also adds missing link to mobile Map school card to fix #124, which I consider a P0 as it prevents navigation to the school profiles on mobile.

Closes #124

---

NOTE: adding links to images on List (not Map) cards will be in a follow-up PR as it requires more work and perhaps refactoring.