### PR TITLE
Fix mobile map card close button

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "scripts": {
-    "dev": "next dev",
+    "dev": "npm run migrate-check && next dev",
     "migrate-check": "prisma migrate diff --from-schema-datamodel=prisma/schema.prisma --to-schema-datasource=prisma/schema.prisma",
     "build": "prisma migrate reset --force && next build",
     "start": "next start",

--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -7,7 +7,7 @@ import Tag from "./Tag";
 interface SchoolCardProps {
   school: School;
   className?: string;
-  onClose: () => void;
+  onClose: (e: React.MouseEvent<HTMLElement>) => void;
 }
 /**
  * SchoolCard: Renders school image and details depending on school clicked on map

--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -25,7 +25,13 @@ interface SchoolCardProps {
  * Map => SchoolCardMap
  *
  */
-
+const LearnMoreButton = () => {
+  return (
+    <button className="w-full rounded-lg bg-blue-500 py-2 text-sm tracking-wide text-white md:w-40">
+      Learn more
+    </button>
+  );
+};
 const SchoolCard: React.FC<SchoolCardProps> = ({
   school,
   onClose,
@@ -41,8 +47,7 @@ const SchoolCard: React.FC<SchoolCardProps> = ({
     (metric) => metric.name == "English Language Learners",
   );
 
-  /* TODO: look into whether or not creating a `WithLink` component
-can simplify this somehow */
+  /* TODO: look into whether or not creating a `WithLink` component can simplify this somehow */
   const SchoolImage = (props: any) => (
     <Image
       src={props.src}
@@ -122,10 +127,11 @@ can simplify this somehow */
             </div>
           </div>
         </div>
-        <Link href={"/school?name=" + encodeURIComponent(school.name)}>
-          <button className="hidden w-full rounded-lg bg-blue-500 py-2 text-sm tracking-wide text-white md:block md:w-40">
-            Learn more
-          </button>
+        <Link
+          className="hidden md:block"
+          href={"/school?name=" + encodeURIComponent(school.name)}
+        >
+          <LearnMoreButton />
         </Link>
       </div>
     </div>

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -48,11 +48,14 @@ const Map: React.FC<Props> = (props) => {
     root?.classList.add(isMap ? "h-auto" : "h-screen");
   };
 
-  const onClose = () => {
+  const onClose = (e: React.MouseEvent<HTMLElement>) => {
     // setting this to false ensures dismissal of school card
     // (whereas setting it to null, the initial value, will show
     // the empty instruction card)
+    /* TODO: consider using something more descriptive like an enum instead */
     setSelectedSchool(false);
+    e.preventDefault();
+    e.stopPropagation();
   };
 
   const handleSchoolSearch = async (searchTerm: string) => {


### PR DESCRIPTION
Closes #126

fix close button; instead of navigating to school card, the close button (the "X") should close the card

TODO for later: Will need to figure out canonical way to show/hide elements based on media query