### PR TITLE
fix whitespace regression caused by adding RootLayout to tailwind tar…

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -17,17 +17,13 @@ function RootLayout({ children }: { children: React.ReactNode }) {
     setIsBannerShowing(!isBannerShowing);
   };
 
-  // NOTE: id="root" is currently needed by the JS view logic in `map.tsx`
-  // to complement the the Tailwind media-query driven classes in
-  // constraining the map height to the viewport for mobile
+  /* NOTE: id="root" is currently required as a hook by the JS view logic in `map.tsx` to help constrain the map height to the mobile viewport */
 
   return (
     <div
       id="root"
-      className={`${inter.className} flex flex-col px-0 md:px-4 ${pathname.includes("/map") || pathname === "/" ? "h-dvh-with-fallback" : "h-auto"}`}
+      className={`${inter.className} flex flex-col px-0 ${pathname.includes("/map") || pathname === "/" ? "h-dvh-with-fallback" : "h-auto"}`}
     >
-      {/* NOTE: `id="root"` is currently required as a hook for code in `map.tsx`*/}
-
       {/* TODO: consider refactoring the pathname-dependent logic to simplify; e.g., use layout components and app routing instead of having to bake pathname logic into this high-level component*/}
       {pathname.includes("/school") && isBannerShowing && (
         <Banner onClose={setToggle}>


### PR DESCRIPTION
This commit was missing from (not added to in time) `fix/100vh`:
- fix whitespace regression caused by adding RootLayout to tailwind targets
- add additional comments