### PR TITLE
remove dismissible banner on desktop

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -4,20 +4,22 @@ const Banner = ({
   onClose,
   children = null,
 }: {
-  onClose?: () => void;
+  onClose?: () => void | undefined;
   children?: React.ReactNode;
 }) => {
   return (
     <div className="flex bg-[#FFDC7C] p-4 text-left text-base font-medium md:text-center">
       <div className="flex-1">{children}</div>
-      <button onClick={onClose} className="ml-2">
-        <Image
-          src={`/circle_close.svg`}
-          alt="Close Icon"
-          width={24}
-          height={24}
-        />
-      </button>
+      {onClose && (
+        <button onClick={onClose} className="ml-2">
+          <Image
+            src={`/circle_close.svg`}
+            alt="Close Icon"
+            width={24}
+            height={24}
+          />
+        </button>
+      )}
     </div>
   );
 };

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -3,7 +3,6 @@ import { Inter } from "next/font/google";
 import Navbar from "@/components/NavBar";
 import Banner from "@/components/Banner";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import ContactUs from "@/components/ContactUs";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -20,6 +19,17 @@ function RootLayout({ children }: { children: React.ReactNode }) {
   const [showContactForm, setShowContactForm] = useState(false);
   const handleOpen = () => setShowContactForm(true);
   const handleClose = () => setShowContactForm(false);
+  const bannerContent = (
+    <>
+      <strong>BETA:</strong> This website is in beta - let us know if you have
+      any&nbsp;
+      <button onClick={handleOpen} className="text-blue-500 hover:underline">
+        feedback/questions
+      </button>
+      <span className="hidden md:inline"> to help us improve it</span>.
+    </>
+  );
+
   /* NOTE: id="root" is currently required as a hook by the JS view logic in `map.tsx` to help constrain the map height to the mobile viewport */
 
   return (
@@ -27,30 +37,22 @@ function RootLayout({ children }: { children: React.ReactNode }) {
       id="root"
       className={`${inter.className} flex flex-col px-0 ${pathname.includes("/map") || pathname === "/" ? "h-dvh-with-fallback" : "h-auto"}`}
     >
-      {/* TODO: consider refactoring the pathname-dependent logic to simplify; e.g., use layout components and app routing instead of having to bake pathname logic into this high-level component*/}
+      {/* TODO: consider refactoring the pathname-dependent logic to simplify; e.g., use layout components and app routing instead of having to bake pathname logic into this high-level component */}
+      {/* {false && */}
       {(pathname.includes("/school") || pathname === "/") &&
         isBannerShowing && (
-          <Banner onClose={setToggle}>
-            <strong>BETA:</strong> This website is in beta - let us know if you
-            have any&nbsp;
-            <button
-              onClick={handleOpen}
-              className="text-blue-500 hover:underline"
-            >
-              feedback/questions
-            </button>
-            <span className="hidden md:inline"> to help us improve it</span>.
+          <>
+            <div className="block md:hidden">
+              <Banner onClose={setToggle}>{bannerContent}</Banner>
+            </div>
+            <div className="hidden md:block">
+              <Banner onClose={setToggle}>{bannerContent}</Banner>
+            </div>
             {showContactForm && <ContactUs handleClose={handleClose} />}
-          </Banner>
+          </>
         )}
       <Navbar />
-      <div
-        className={
-          pathname === "/" ? "absolute bottom-0 left-0 right-0 top-0" : "flex-1"
-        }
-      >
-        {children}
-      </div>
+      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -38,7 +38,6 @@ function RootLayout({ children }: { children: React.ReactNode }) {
       className={`${inter.className} flex flex-col px-0 ${pathname.includes("/map") || pathname === "/" ? "h-dvh-with-fallback" : "h-auto"}`}
     >
       {/* TODO: consider refactoring the pathname-dependent logic to simplify; e.g., use layout components and app routing instead of having to bake pathname logic into this high-level component */}
-      {/* {false && */}
       {(pathname.includes("/school") || pathname === "/") &&
         isBannerShowing && (
           <>
@@ -46,7 +45,7 @@ function RootLayout({ children }: { children: React.ReactNode }) {
               <Banner onClose={setToggle}>{bannerContent}</Banner>
             </div>
             <div className="hidden md:block">
-              <Banner onClose={setToggle}>{bannerContent}</Banner>
+              <Banner>{bannerContent}</Banner>
             </div>
             {showContactForm && <ContactUs handleClose={handleClose} />}
           </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   return (
     <>
       <main className="relative flex h-full flex-row justify-between p-4">
-        <section className="flex flex-1 flex-col items-center justify-center gap-8 lg:gap-11">
+        <section className="mt-8 flex flex-1 flex-col items-center gap-8 md:mt-0 md:justify-center lg:gap-11">
           <header className="text-center">
             <h1 className="text-3xl font-medium tracking-wider xl:text-5xl xl:leading-normal">
               Get <span className="text-[#F15437]">Involved</span> with <br />


### PR DESCRIPTION
This PR:
- allows dismissability via close button of beta banner only on desktop width screen sizes

And also:
- fixes clickability/touchability of the banner (including link and close button) on the splash page
- uses a different approach to centering the body content on the splash page (centered on desktop, not centered on mobile) to improve readability

Potential future tweak: Improve readability in landscape mode and/or account for touch-compatible devices

Closes #127