### PR TITLE
rename web site title and add title tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# About Support SFUSD
+# About Support SF Schools
 
-Hello! Thanks for checking out Support SFUSD. We started this project in summer 2022 to solve a big problem in San Francisco. Schools need help. And people who live or work in SF want to support local schools, but they don’t know how. We are building a [website](https://support-sfusd.vercel.app/) to help solve that.
+Hello! Thanks for checking out Support SF Schools. We started this project in summer 2022 to solve a big problem in San Francisco. Schools need help. And people who live or work in SF want to support local schools, but they don’t know how. We are building a [website](https://supportsfschools.org/) to help solve that.
 
 <br>
 

--- a/src/components/ContactUs.tsx
+++ b/src/components/ContactUs.tsx
@@ -6,9 +6,9 @@ type ContactUsProps = {
 };
 
 /**
- * ContactUs: A modal form for users to contact the Support SFUSD team.
+ * ContactUs: A modal form for users to contact the Support SF Schools team.
  * - Validates email input before sending the message.
- * - Sends the message to the Support SFUSD team using emailjs.
+ * - Sends the message to the Support SF Schools team using emailjs.
  *
  * State:
  * - formData: an object containing the user's name, email, and message
@@ -53,7 +53,7 @@ const ContactUs: React.FC<ContactUsProps> = ({ handleClose }) => {
   const form = React.useRef<HTMLFormElement | null>(null);
 
   /**
-   * sendEmail: Sends the email to the Support SFUSD team using emailjs.
+   * sendEmail: Sends the email to the Support SF Schools team using emailjs.
    * Validates the email input before sending the message.
    */
   const sendEmail = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -37,7 +37,7 @@ const Navbar = () => {
           {/* Home Icon */}
           <Link href="/map" className="flex items-center gap-2">
             <Image src="/logo.png" alt="Home" width={32} height={32} />
-            <p className="h-fit max-md:hidden">Support SFUSD</p>
+            <p className="h-fit max-md:hidden">Support SF Schools</p>
           </Link>
 
           {/* Links on desktop */}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,6 +5,7 @@ class MyDocument extends Document {
     return (
       <Html className="scroll-smooth">
         <Head>
+          <title>Support SF Schools</title>
           <link
             href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap"
             rel="stylesheet"

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -24,7 +24,7 @@ const About = () => {
             Hello!
           </h1>
           <p>
-            Support SFUSD is run by an all-volunteer team at{" "}
+            Support SF Schools is run by an all-volunteer team at{" "}
             <a
               href="https://www.sfcivictech.org/about"
               target="_blank"
@@ -53,9 +53,9 @@ const About = () => {
             neighborhood after their kids graduated and have free time to
             volunteer. Alumni who are back in San Francisco and want to
             reconnect with schools. People from all backgrounds who believe in
-            the power of education to change lives. Support SFUSD is designed to
-            bring them closer to the schools in their neighborhood, while
-            helping meet school needs.
+            the power of education to change lives. Support SF Schools is
+            designed to bring them closer to the schools in their neighborhood,
+            while helping meet school needs.
           </p>
           <p>
             This website is in beta and is a work in progress. Our beta focuses


### PR DESCRIPTION
adds `title` tag and renames all (text) instances of "Support SFUSD" to "Support SF Schools"