### PR TITLE
added blurDataURL property to larger images

### DIFF
--- a/src/components/MapListCard.tsx
+++ b/src/components/MapListCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
-import Image from "next/image";
 import { School } from "@/types/school";
+import { blurDataURL } from "@/lib/imageConfig";
+import Image from "next/image";
 import Link from "next/link";
 import Tag from "./Tag";
 
@@ -83,9 +84,17 @@ const MapListCard: React.FC<MapListCardProps> = ({
         </div>
       </div>
       <div
-        className={`transition-max-height relative col-span-4 rounded-r-lg bg-cover bg-center duration-[700ms] md:col-span-3 ${isExpanded ? "max-h-[300px]" : "max-h-[88px]"}`}
-        style={{ backgroundImage: `url(school_img/${img})` }}
+        className={`transition-max-height relative col-span-4 rounded-r-lg duration-[700ms] md:col-span-3 ${isExpanded ? "max-h-[300px]" : "max-h-[88px]"}`}
       >
+        <Image
+          src={`/school_img/${school.img}`}
+          placeholder="blur"
+          blurDataURL={blurDataURL}
+          alt="School Image"
+          fill
+          className="rounded-r-lg object-cover"
+        />
+
         <Image
           src="/icons/dropdown-icon.svg"
           alt="Arrow Icon"

--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -3,6 +3,7 @@ import { Program, School } from "@/types/school";
 import Image from "next/image";
 import Link from "next/link";
 import Tag from "./Tag";
+import { blurDataURL } from "@/lib/imageConfig";
 
 interface SchoolCardProps {
   school: School;
@@ -52,6 +53,8 @@ const SchoolCard: React.FC<SchoolCardProps> = ({
     <Image
       src={props.src}
       alt={props.alt}
+      placeholder="blur"
+      blurDataURL={blurDataURL}
       width={1000}
       height={500}
       className={`h-40 max-h-[20vh] rounded-l-2xl object-cover md:max-h-none md:rounded-b-lg md:rounded-t-2xl ${props.className ? props.className : ""}`}

--- a/src/components/schoolPageComponents/Card.tsx
+++ b/src/components/schoolPageComponents/Card.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { blurDataURL } from "@/lib/imageConfig";
 
 const Card = (props: any) => {
   const { title, description, img, index } = props;
@@ -11,6 +12,8 @@ const Card = (props: any) => {
         className="h-48 rounded-lg object-cover"
         width={1000}
         height={1000}
+        placeholder="blur"
+        blurDataURL={blurDataURL}
       />
       <div className="p-2">
         <h1 className="font-medium">{title}</h1>

--- a/src/components/schoolPageComponents/SchoolDonation.tsx
+++ b/src/components/schoolPageComponents/SchoolDonation.tsx
@@ -1,6 +1,7 @@
 import { School } from "@/types/school";
 import BannerWrapper from "./BannerWrapper";
 import HeadingContentWrapper from "./HeadingContentWrapper";
+import { blurDataURL } from "@/lib/imageConfig";
 import Image from "next/image";
 
 const SchoolDonation: React.FC<{ school: School }> = ({ school }) => {
@@ -57,6 +58,8 @@ const SchoolDonation: React.FC<{ school: School }> = ({ school }) => {
             alt="donation graphic"
             width={500}
             height={1000}
+            placeholder="blur"
+            blurDataURL={blurDataURL}
           />
         }
         className={

--- a/src/components/schoolPageComponents/SchoolVolunteer.tsx
+++ b/src/components/schoolPageComponents/SchoolVolunteer.tsx
@@ -4,6 +4,7 @@ import BannerWrapper from "./BannerWrapper";
 import Link from "next/link";
 import HeadingContentWrapper from "./HeadingContentWrapper";
 import CardList from "./CardList";
+import { blurDataURL } from "@/lib/imageConfig";
 
 const SchoolVolunteer: React.FC<{ school: School }> = ({ school }) => {
   interface volunteer {
@@ -37,6 +38,8 @@ const SchoolVolunteer: React.FC<{ school: School }> = ({ school }) => {
             alt="volunteer graphic"
             width={500}
             height={1000}
+            placeholder="blur"
+            blurDataURL={blurDataURL}
           />
         }
         right={

--- a/src/lib/imageConfig.ts
+++ b/src/lib/imageConfig.ts
@@ -1,0 +1,3 @@
+// generated using https://png-pixel.com/
+export const blurDataURL =
+  "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mN8/R8AAtsB7JKxzdUAAAAASUVORK5CYII=";

--- a/src/pages/school.tsx
+++ b/src/pages/school.tsx
@@ -7,6 +7,7 @@ import SchoolTestimonial from "@/components/schoolPageComponents/SchoolTestimoni
 import SchoolVolunteer from "@/components/schoolPageComponents/SchoolVolunteer";
 import prisma from "@/lib/prisma";
 import { School } from "@/types/school";
+import { blurDataURL } from "@/lib/imageConfig";
 import { GetStaticProps } from "next";
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -44,6 +45,8 @@ const Profile: React.FC<Props> = (props) => {
               alt={school.name + " image"}
               width={2000}
               height={2000}
+              placeholder="blur"
+              blurDataURL={blurDataURL}
             />
           </div>
           <div className="relative mx-auto flex flex-col gap-10 p-6 pt-2 md:py-20 lg:w-4/5 2xl:w-2/3">
@@ -53,6 +56,8 @@ const Profile: React.FC<Props> = (props) => {
               alt={school.name + " logo"}
               width={1000}
               height={1000}
+              placeholder="blur"
+              blurDataURL={blurDataURL}
             />
             <SchoolHeader school={school} />
             <SchoolAbout school={school} />


### PR DESCRIPTION
Added a [blurDataURL](https://nextjs.org/docs/pages/api-reference/components/image#blurdataurl) to larger images to improve image loading, fixing issue #145.

For the placeholder image, this PR uses a single pixel generated by [PNG Pixel](https://png-pixel.com/), as suggested in the [NextJS documentation](https://nextjs.org/docs/pages/api-reference/components/image#blurdataurl). This approach is chosen for its optimal performance due to the small size (~120 bytes), resulting in a solid color placeholder.

While more complex, blurred image placeholders can provide a slightly better visual experience, but they come with an increased loading time. After experimenting with this, I thought that the added complexity and loading time did not justify the benefits. Implementing this would require adding another field to the database to store these encoded images, with each image being roughly 6-8kb. For those interested, you can explore and play with examples using the [Next.js Image blurDataURL generator](https://blurred.dev/).

Feedback and suggestions on this implementation are welcome!