### PR TITLE
Fix/add more a11y to map

### DIFF
--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -107,6 +107,7 @@ const MapboxMap = ({
             var i;
             for (i = 0; i < marker_array.length; i++) {
               // TODO: refactor in case we add more classes
+              // TODO: refactor to explicitly track what is is isn't
               marker_array[i].className =
                 "marker mapboxgl-marker mapboxgl-marker-anchor-center";
             }
@@ -114,6 +115,10 @@ const MapboxMap = ({
             elRef.className =
               "marker-selected mapboxgl-marker mapboxgl-marker-anchor-center";
             elRef.focus();
+            // NOTE: workaround for popup disappearing on keyboard selection
+            if (!schoolMarker.getPopup().isOpen()) {
+              schoolMarker.togglePopup();
+            }
           });
           elRef.addEventListener("mouseover", () => {
             if (!schoolMarker.getPopup().isOpen()) {

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -131,6 +131,11 @@ const MapboxMap = ({
             }
           });
           elRef.addEventListener("focus", () => {
+            // show popup on focus
+            if (!schoolMarker.getPopup().isOpen()) {
+              schoolMarker.togglePopup();
+            }
+
             // if we are outside of the bounds, recenter/rezoom (intended for keyboard navigation)
             const lngLat = schoolMarker.getLngLat();
             const bounds = map.getBounds();

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -41,6 +41,7 @@ h6 * {
 .marker:hover,
 .marker:focus-within {
   background-image: url("/marker_hover.svg");
+  z-index: 10;
 }
 
 .marker:focus-within,
@@ -48,6 +49,7 @@ h6 * {
   outline: 2px solid rgba(127, 127, 255, 0.8);
   background-color: rgba(255, 255, 255, 0.5);
   border-radius: 5px;
+  z-index: 10;
 }
 
 /* .marker:active, .marker:focus {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,20 +44,10 @@ h6 * {
 }
 
 .marker:focus-within,
-.marker-selected {
+.marker-selected:focus-within {
   outline: 2px solid rgba(127, 127, 255, 0.8);
   background-color: rgba(255, 255, 255, 0.5);
   border-radius: 5px;
-}
-
-.marker-selected {
-  background-image: url("/marker_select.svg");
-  background-size: cover;
-  width: 45px;
-  height: 45px;
-  border-radius: 0;
-  cursor: pointer;
-  outline: none;
 }
 
 /* .marker:active, .marker:focus {
@@ -71,6 +61,7 @@ h6 * {
   height: 45px;
   border-radius: 0;
   cursor: pointer;
+  outline: none;
 }
 
 .golden-gate-marker {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,7 +38,8 @@ h6 * {
   cursor: pointer;
 }
 
-.marker:hover {
+.marker:hover,
+.marker:focus-within {
   background-image: url("/marker_hover.svg");
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -43,6 +43,13 @@ h6 * {
   background-image: url("/marker_hover.svg");
 }
 
+.marker:focus-within,
+.marker-selected {
+  outline: 2px solid rgba(127, 127, 255, 0.8);
+  background-color: rgba(255, 255, 255, 0.5);
+  border-radius: 5px;
+}
+
 .marker-selected {
   background-image: url("/marker_select.svg");
   background-size: cover;
@@ -50,6 +57,7 @@ h6 * {
   height: 45px;
   border-radius: 0;
   cursor: pointer;
+  outline: none;
 }
 
 /* .marker:active, .marker:focus {


### PR DESCRIPTION
For map marker, add the following for keyboard nav/a11y:
- Trigger popup on focus
- Add focus styling by copying active styling
- Replace outline effect with something closer to our design

Also addresses #210 so that focused marker comes to foreground.