### PR TITLE
Fix Auto Scroll on expand

### DIFF
--- a/src/components/MapList.tsx
+++ b/src/components/MapList.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import MapListCard from "./MapListCard";
 import { School } from "@/types/school";
 
 type MapListProps = {
   schools: School[];
-  setSelectedSchool: (school: School | null) => void;
+  setSelectedSchool: (school: School | false | null) => void;
   selectedSchool: School | false | null;
   onModalOpen: () => void;
 };
@@ -26,30 +26,30 @@ const MapList = ({
   selectedSchool,
   onModalOpen,
 }: MapListProps) => {
-  // Create a ref for the container div
   const containerRef = useRef<HTMLDivElement>(null);
+  const [expandedSchool, setExpandedSchool] = useState<string | null>(null);
 
-  // Scroll to selected school when it changes
+  const handleExpansionComplete = (schoolName: string) => {
+    setExpandedSchool(schoolName);
+  };
+
   useEffect(() => {
-    if (selectedSchool && containerRef.current) {
-      const index = schools.findIndex(
-        (school) => school.name == selectedSchool.name,
-      );
+    if (expandedSchool && containerRef.current) {
+      const selectedElement = containerRef.current.querySelector(
+        `[data-school-name="${expandedSchool}"]`,
+      ) as HTMLElement;
 
-      const scrollPosition = index * 88;
-      if (window.innerWidth > 768) {
-        containerRef.current.scrollTo({
-          top: scrollPosition,
+      if (selectedElement) {
+        selectedElement.scrollIntoView({
           behavior: "smooth",
-        });
-      } else {
-        window.scrollTo({
-          top: scrollPosition,
-          behavior: "smooth",
+          block: "nearest",
         });
       }
+
+      // Reset expanded school after scrolling
+      setExpandedSchool(null);
     }
-  }, [selectedSchool, schools]);
+  }, [expandedSchool]);
 
   return (
     <div className="flex h-full flex-col">
@@ -59,15 +59,16 @@ const MapList = ({
       >
         {schools
           .sort((a, b) => a.name.localeCompare(b.name))
-          .map((school, index) => (
+          .map((school) => (
             <MapListCard
-              key={school.name} // @todo: add id to School type so we can use that as key
+              key={school.name}
               school={school}
               setSelectedSchool={setSelectedSchool}
               isExpanded={
                 selectedSchool ? school.name === selectedSchool.name : false
               }
               onModalOpen={onModalOpen}
+              onExpansionComplete={handleExpansionComplete}
             />
           ))}
       </div>

--- a/src/components/MapList.tsx
+++ b/src/components/MapList.tsx
@@ -26,30 +26,9 @@ const MapList = ({
   selectedSchool,
   onModalOpen,
 }: MapListProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [expandedSchool, setExpandedSchool] = useState<string | null>(null);
-
-  const handleExpansionComplete = (schoolId: string) => {
-    if (containerRef.current) {
-      const selectedElement = containerRef.current.querySelector(
-        `[id="${schoolId}"]`,
-      ) as HTMLElement;
-
-      if (selectedElement) {
-        selectedElement.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-        });
-      }
-    }
-  };
-
   return (
     <div className="flex h-full flex-col">
-      <div
-        className="flex h-full flex-col gap-2 overflow-auto max-md:mb-4 md:gap-4"
-        ref={containerRef}
-      >
+      <div className="flex h-full flex-col gap-2 overflow-auto max-md:mb-4 md:gap-4">
         {schools
           .sort((a, b) => a.name.localeCompare(b.name))
           .map((school) => (
@@ -58,10 +37,9 @@ const MapList = ({
               school={school}
               setSelectedSchool={setSelectedSchool}
               isExpanded={
-                selectedSchool ? school.name === selectedSchool.name : false
+                selectedSchool ? school.id === selectedSchool.id : false
               }
               onModalOpen={onModalOpen}
-              onExpansionComplete={handleExpansionComplete}
             />
           ))}
       </div>

--- a/src/components/MapList.tsx
+++ b/src/components/MapList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import MapListCard from "./MapListCard";
 import { School } from "@/types/school";
 

--- a/src/components/MapList.tsx
+++ b/src/components/MapList.tsx
@@ -29,14 +29,10 @@ const MapList = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [expandedSchool, setExpandedSchool] = useState<string | null>(null);
 
-  const handleExpansionComplete = (schoolName: string) => {
-    setExpandedSchool(schoolName);
-  };
-
-  useEffect(() => {
-    if (expandedSchool && containerRef.current) {
+  const handleExpansionComplete = (schoolId: string) => {
+    if (containerRef.current) {
       const selectedElement = containerRef.current.querySelector(
-        `[data-school-name="${expandedSchool}"]`,
+        `[id="${schoolId}"]`,
       ) as HTMLElement;
 
       if (selectedElement) {
@@ -45,11 +41,8 @@ const MapList = ({
           block: "nearest",
         });
       }
-
-      // Reset expanded school after scrolling
-      setExpandedSchool(null);
     }
-  }, [expandedSchool]);
+  };
 
   return (
     <div className="flex h-full flex-col">
@@ -61,7 +54,7 @@ const MapList = ({
           .sort((a, b) => a.name.localeCompare(b.name))
           .map((school) => (
             <MapListCard
-              key={school.name}
+              key={school.id}
               school={school}
               setSelectedSchool={setSelectedSchool}
               isExpanded={

--- a/src/components/MapListCard.tsx
+++ b/src/components/MapListCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useEffect, useCallback } from "react";
 import { School } from "@/types/school";
 import { blurDataURL } from "@/lib/imageConfig";
 import Image from "next/image";
@@ -8,8 +8,9 @@ import Tag from "./Tag";
 type MapListCardProps = {
   school: School;
   setSelectedSchool: (school: School | null) => void;
-  isExpanded: Boolean;
+  isExpanded: boolean;
   onModalOpen: () => void;
+  onExpansionComplete: (schoolName: string) => void;
 };
 
 /**
@@ -34,6 +35,7 @@ const MapListCard: React.FC<MapListCardProps> = ({
   setSelectedSchool,
   isExpanded,
   onModalOpen,
+  onExpansionComplete,
 }) => {
   const { img, name, neighborhood } = school;
 
@@ -47,6 +49,17 @@ const MapListCard: React.FC<MapListCardProps> = ({
     (metric) => metric.name == "English Language Learners",
   );
 
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleTransitionEnd = useCallback(
+    (e: React.TransitionEvent<HTMLDivElement>) => {
+      if (e.propertyName === "max-height" && isExpanded) {
+        onExpansionComplete(school.name);
+      }
+    },
+    [school.name, onExpansionComplete, isExpanded],
+  );
+
   function onClick(e: React.MouseEvent<HTMLDivElement>) {
     if (isExpanded) {
       setSelectedSchool(null);
@@ -56,9 +69,14 @@ const MapListCard: React.FC<MapListCardProps> = ({
   }
   return (
     <div
-      className={`grid cursor-pointer grid-cols-10 rounded-lg border-2 bg-white max-md:overflow-hidden ${isExpanded ? "max-h-[300px]" : "max-h-[104px]"} transition-max-height relative duration-[700ms]`}
+      ref={cardRef}
+      className={`grid cursor-pointer grid-cols-10 rounded-lg border-2 bg-white max-md:overflow-hidden ${
+        isExpanded ? "max-h-[300px]" : "max-h-[104px]"
+      } transition-max-height relative duration-[700ms]`}
       onClick={onClick}
+      onTransitionEnd={handleTransitionEnd}
       id={name}
+      data-school-name={school.name}
     >
       <div className="col-span-6 justify-center overflow-hidden px-4 pb-4 transition-all ease-in-out md:col-span-7">
         <div className="flex h-[104px] flex-col justify-center">
@@ -100,7 +118,9 @@ const MapListCard: React.FC<MapListCardProps> = ({
         </div>
       </div>
       <div
-        className={`transition-max-height relative col-span-4 rounded-r-lg duration-[700ms] md:col-span-3 ${isExpanded ? "max-h-[300px]" : "max-h-[104px]"}`}
+        className={`transition-max-height relative col-span-4 rounded-r-lg duration-[700ms] md:col-span-3 ${
+          isExpanded ? "max-h-[300px]" : "max-h-[104px]"
+        }`}
       >
         <Image
           src={`/school_img/${school.img}`}
@@ -116,7 +136,9 @@ const MapListCard: React.FC<MapListCardProps> = ({
           alt="Arrow Icon"
           width={24}
           height={24}
-          className={`absolute bottom-1.5 right-1.5 transition duration-[700ms] ${isExpanded ? "rotate-[-180deg]" : "rotate-0"}`}
+          className={`absolute bottom-1.5 right-1.5 transition duration-[700ms] ${
+            isExpanded ? "rotate-[-180deg]" : "rotate-0"
+          }`}
         />
       </div>
     </div>

--- a/src/components/MapListCard.tsx
+++ b/src/components/MapListCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, forwardRef } from "react";
+import React, { useRef } from "react";
 import { School } from "@/types/school";
 import { blurDataURL } from "@/lib/imageConfig";
 import Image from "next/image";

--- a/src/components/MapListCard.tsx
+++ b/src/components/MapListCard.tsx
@@ -62,11 +62,6 @@ const MapListCard = ({
       setSelectedSchool(school);
     }
   }
-  useEffect(() => {
-    if (isExpanded) {
-      cardRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    }
-  }, [isExpanded]);
 
   return (
     <div

--- a/src/components/MapListCard.tsx
+++ b/src/components/MapListCard.tsx
@@ -37,7 +37,7 @@ const MapListCard: React.FC<MapListCardProps> = ({
   onModalOpen,
   onExpansionComplete,
 }) => {
-  const { img, name, neighborhood } = school;
+  const { id, img, name, neighborhood } = school;
 
   const students = school.metrics.find(
     (metric) => metric.name == "Students Enrolled",
@@ -54,10 +54,10 @@ const MapListCard: React.FC<MapListCardProps> = ({
   const handleTransitionEnd = useCallback(
     (e: React.TransitionEvent<HTMLDivElement>) => {
       if (e.propertyName === "max-height" && isExpanded) {
-        onExpansionComplete(school.name);
+        onExpansionComplete(school.id);
       }
     },
-    [school.name, onExpansionComplete, isExpanded],
+    [school.id, onExpansionComplete, isExpanded],
   );
 
   function onClick(e: React.MouseEvent<HTMLDivElement>) {
@@ -75,8 +75,7 @@ const MapListCard: React.FC<MapListCardProps> = ({
       } transition-max-height relative duration-[700ms]`}
       onClick={onClick}
       onTransitionEnd={handleTransitionEnd}
-      id={name}
-      data-school-name={school.name}
+      id={id}
     >
       <div className="col-span-6 justify-center overflow-hidden px-4 pb-4 transition-all ease-in-out md:col-span-7">
         <div className="flex h-[104px] flex-col justify-center">

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -45,22 +45,8 @@ const Map: React.FC<Props> = (props) => {
   const [modalIsOpen, setModalIsOpen] = useState(false);
 
   useEffect(() => {
-    // Check if the current URL has the #list hash
     const isListView = router.asPath.includes("#list");
     setIsMap(!isListView);
-
-    // Add event listener for popstate (browser back/forward buttons)
-    const handlePopState = () => {
-      const isListViewAfterPop = window.location.hash === "#list";
-      setIsMap(!isListViewAfterPop);
-    };
-
-    window.addEventListener("popstate", handlePopState);
-
-    // Cleanup
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
   }, [router.asPath]);
 
   const openModal = () => {

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -11,7 +11,6 @@ import prisma from "@/lib/prisma";
 import Image from "next/image";
 import Link from "next/link";
 import HighPriorityModal from "@/components/HighPriorityModal";
-import { useRouter } from "next/router";
 
 interface DropdownItem<ItemType> {
   label: string;
@@ -37,17 +36,11 @@ const schoolCardPlaceholderText =
   "San Francisco public schools are closed until mid August. Click on the school closest to you to learn about opportunities in the fall.";
 
 const Map: React.FC<Props> = (props) => {
-  const router = useRouter();
   const [selectedSchool, setSelectedSchool] = useState<School | false | null>(
     null,
   );
   const [isMap, setIsMap] = useState(true);
   const [modalIsOpen, setModalIsOpen] = useState(false);
-
-  useEffect(() => {
-    const isListView = router.asPath.includes("#list");
-    setIsMap(!isListView);
-  }, [router.asPath]);
 
   const openModal = () => {
     setModalIsOpen(true);
@@ -58,14 +51,17 @@ const Map: React.FC<Props> = (props) => {
   };
 
   const setToggle = () => {
-    const newIsMap = !isMap;
-    setIsMap(newIsMap);
+    setIsMap(!isMap);
 
-    if (newIsMap) {
-      router.push("/map", undefined, { shallow: true });
-    } else {
-      router.push("/map#list", undefined, { shallow: true });
-    }
+    const [mapRootClass, listRootClass] = ["h-dvh-with-fallback", "h-auto"];
+
+    // base new layout on isMap BEFORE it changes to the new value
+    // (otherwise the `h-dvh-with-fallback` appears to apply too late)
+    // FIXME: investigate how to do this in a more canonical NextJS/React way
+    const root = document.getElementById("root");
+    // toggle between map and list layout
+    root?.classList.remove(isMap ? mapRootClass : listRootClass);
+    root?.classList.add(isMap ? listRootClass : mapRootClass);
   };
 
   const onClose = (e: React.MouseEvent<HTMLElement>) => {

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -11,6 +11,7 @@ import prisma from "@/lib/prisma";
 import Image from "next/image";
 import Link from "next/link";
 import HighPriorityModal from "@/components/HighPriorityModal";
+import { useRouter } from "next/router";
 
 interface DropdownItem<ItemType> {
   label: string;
@@ -36,11 +37,31 @@ const schoolCardPlaceholderText =
   "San Francisco public schools are closed until mid August. Click on the school closest to you to learn about opportunities in the fall.";
 
 const Map: React.FC<Props> = (props) => {
+  const router = useRouter();
   const [selectedSchool, setSelectedSchool] = useState<School | false | null>(
     null,
   );
   const [isMap, setIsMap] = useState(true);
   const [modalIsOpen, setModalIsOpen] = useState(false);
+
+  useEffect(() => {
+    // Check if the current URL has the #list hash
+    const isListView = router.asPath.includes("#list");
+    setIsMap(!isListView);
+
+    // Add event listener for popstate (browser back/forward buttons)
+    const handlePopState = () => {
+      const isListViewAfterPop = window.location.hash === "#list";
+      setIsMap(!isListViewAfterPop);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    // Cleanup
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [router.asPath]);
 
   const openModal = () => {
     setModalIsOpen(true);
@@ -51,17 +72,14 @@ const Map: React.FC<Props> = (props) => {
   };
 
   const setToggle = () => {
-    setIsMap(!isMap);
+    const newIsMap = !isMap;
+    setIsMap(newIsMap);
 
-    const [mapRootClass, listRootClass] = ["h-dvh-with-fallback", "h-auto"];
-
-    // base new layout on isMap BEFORE it changes to the new value
-    // (otherwise the `h-dvh-with-fallback` appears to apply too late)
-    // FIXME: investigate how to do this in a more canonical NextJS/React way
-    const root = document.getElementById("root");
-    // toggle between map and list layout
-    root?.classList.remove(isMap ? mapRootClass : listRootClass);
-    root?.classList.add(isMap ? listRootClass : mapRootClass);
+    if (newIsMap) {
+      router.push("/map", undefined, { shallow: true });
+    } else {
+      router.push("/map#list", undefined, { shallow: true });
+    }
   };
 
   const onClose = (e: React.MouseEvent<HTMLElement>) => {

--- a/src/types/school.ts
+++ b/src/types/school.ts
@@ -1,4 +1,5 @@
 export interface School {
+  id: string;
   name: string;
   address?: string;
   neighborhood?: string;


### PR DESCRIPTION
Fixes #226 by using preferred DOM _scrollIntoView_ instead of fixed-height scrolling. We also watch for the css animation to complete before auto scrolling, this is what really fixes this issue. NOTE: there is a delay because we have to expand first, then auto-scroll, but this is only really noticeable when scrolled to the bottom of the list and clicking on the last school.

Also adds 'id' to the School type so that we aren't using school name in react components.

Also a little bit of code cleanup.