### PR TITLE
Fix faster search results for dropdown

### DIFF
--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -75,7 +75,7 @@ const Map: React.FC<Props> = (props) => {
   };
 
   const handleSchoolSearch = async (searchTerm: string) => {
-    const results = props.schools
+    return props.schools
       .filter(({ name }) =>
         name.toUpperCase().includes(searchTerm.toUpperCase()),
       )
@@ -84,8 +84,6 @@ const Map: React.FC<Props> = (props) => {
         value: school.name,
         item: school,
       }));
-
-    return results;
   };
 
   const itemSelect = (selection: DropdownItem<School>) => {

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -75,15 +75,17 @@ const Map: React.FC<Props> = (props) => {
   };
 
   const handleSchoolSearch = async (searchTerm: string) => {
-    const response = await fetch(
-      `/api/searchSchools?searchTerm=${searchTerm}`,
-    ).then((res) => res.json() as Promise<{ schools: School[] }>);
+    const results = props.schools
+      .filter(({ name }) =>
+        name.toUpperCase().includes(searchTerm.toUpperCase()),
+      )
+      .map((school) => ({
+        label: school.name,
+        value: school.name,
+        item: school,
+      }));
 
-    return response.schools.map((school) => ({
-      label: school.name,
-      value: school.name,
-      item: school,
-    }));
+    return results;
   };
 
   const itemSelect = (selection: DropdownItem<School>) => {


### PR DESCRIPTION
Fixes #217. Currently the map component issues a fetch and a DB query with every keystroke during the search. This is leading to the choppy experience. This PR replaces the fetch and query with an in-memory filter.