### PR TITLE
Chore/whitelist vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,13 @@ yarn-error.log*
 
 # vercel
 .vercel
-.vscode
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 
 # typescript
 *.tsbuildinfo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode", "bradlc.vscode-tailwindcss"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "files.associations": {
-    "*.css": "tailwindcss"
+    "globals.css": "tailwindcss"
   }
 }


### PR DESCRIPTION
Some VSCode config are helpful when they are project-wide including extension recommendations and a subset of the settings for easier onboarding.

With a recent commit, both IntelliSense inside CSS files of Tailwind API and extension recommendations were removed.

This PR restores the above by:
- replaces blanket `.vscode` git ignore w/ignoring folder and whitelisting specific files
- adds specific files to whitelist

It also:
- adds Prettier extension recommendation since we rely on Prettier for formatting (avoids having to do this sort of thing: https://github.com/sfbrigade/support-sfusd/pull/250 and simplifies diffs; we can add a precommit hook later)
- narrows scope of tailwind CSS file association to just `globals.css`