### PR TITLE
Roll back autozoom on click while keeping pan-on-search intact

### DIFF
--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -156,12 +156,12 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
               schoolMarker.togglePopup();
             }
 
-            // if we are outside of the bounds, recenter/rezoom (intended for keyboard navigation)
             const lngLat = schoolMarker.getLngLat();
             const bounds = map.getBounds();
 
+            // if we have focused on a school outside of the bounds of the map, recenter (e.g., for keyboard navigation)
             if (!bounds.contains(lngLat)) {
-              // pan to marker
+              // pan to school marker
               map.flyTo({
                 center: [lngLat.lng, lngLat.lat],
                 ...flyToOptions,
@@ -219,10 +219,17 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
           userHasInteracted.current = true;
         } else {
           // Use flyTo for all other cases
-          mapRef.current.flyTo({
-            center: [lngLat.lng, lngLat.lat],
-            ...flyToOptions,
-          });
+
+          // if we are outside of the bounds, recenter (intended for keyboard navigation)
+          const bounds = mapRef.current.getBounds();
+
+          if (!bounds.contains(lngLat)) {
+            // pan to marker
+            mapRef.current.flyTo({
+              center: [lngLat.lng, lngLat.lat],
+              ...flyToOptions,
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
The following has been modified:
- on school focus, panning to center happens only if school is out of bounds
- on useEffect (when any of selectedSchool, mapLoaded, flyToOptions*, userHasInteracted change), panning (or jumping) to center happens only if school is out of bounds

Closes #259

*is static, so candidate for removal

---

Potential TODOs for this or future PR:
- [ ] consolidate some of the panning / jumping code
- [ ] look for opportunities to combine the focus handler and the useEffect