### PR TITLE
Recenter if map marker is obscured by other elements

### DIFF
--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -17,13 +17,11 @@ const isVisible = (marker: mapboxgl.Marker, map: mapboxgl.Map) => {
 
   // check if marker is obscured by other elements
   const markerEl = marker.getElement();
-  const markerRect = markerEl.getBoundingClientRect();
+  const { top, right, bottom, left } = markerEl.getBoundingClientRect();
   // find center of marker
   // TODO: check entire rectangle instead
-  const markerX =
-    markerRect.left + Math.round(markerRect.right - markerRect.left) / 2;
-  const markerY =
-    markerRect.top + Math.round(markerRect.bottom - markerRect.top) / 2;
+  const markerX = left + Math.round(right - left) / 2;
+  const markerY = top + Math.round(bottom - top) / 2;
 
   const topEl = document.elementFromPoint(markerX, markerY);
 

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -213,16 +213,23 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
 
         if (!userHasInteracted.current) {
           // Use jumpTo when returning from detail page. it's less dizzying.
-          mapRef.current.jumpTo({
-            center: [lngLat.lng, lngLat.lat],
-          });
-          userHasInteracted.current = true;
+
+          const bounds = mapRef.current.getBounds();
+
+          // if we have focused on a school outside of the bounds of the map, recenter
+          if (!bounds.contains(lngLat)) {
+            // jump to marker
+            mapRef.current.jumpTo({
+              center: [lngLat.lng, lngLat.lat],
+            });
+            userHasInteracted.current = true;
+          }
         } else {
           // Use flyTo for all other cases
 
-          // if we are outside of the bounds, recenter (intended for keyboard navigation)
           const bounds = mapRef.current.getBounds();
 
+          // if we have focused on a school outside of the bounds of the map, recenter
           if (!bounds.contains(lngLat)) {
             // pan to marker
             mapRef.current.flyTo({

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -156,12 +156,12 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
               schoolMarker.togglePopup();
             }
 
-            // if we are outside of the bounds, recenter/rezoom (intended for keyboard navigation)
             const lngLat = schoolMarker.getLngLat();
             const bounds = map.getBounds();
 
+            // if we have focused on a school outside of the bounds of the map, recenter (e.g., for keyboard navigation)
             if (!bounds.contains(lngLat)) {
-              // pan to marker
+              // pan to school marker
               map.flyTo({
                 center: [lngLat.lng, lngLat.lat],
                 ...flyToOptions,
@@ -219,10 +219,17 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
           userHasInteracted.current = true;
         } else {
           // Use flyTo for all other cases
-          mapRef.current.flyTo({
-            center: [lngLat.lng, lngLat.lat],
-            ...flyToOptions,
-          });
+
+          // if we are outside of the bounds, recenter (intended for keyboard navigation)
+          const bounds = mapRef.current.getBounds();
+
+          if (!bounds.contains(lngLat)) {
+            // pan to marker
+            mapRef.current.flyTo({
+              center: [lngLat.lng, lngLat.lat],
+              ...flyToOptions,
+            });
+          }
         }
       }
     }

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -19,13 +19,23 @@ const isVisible = (marker: mapboxgl.Marker, map: mapboxgl.Map) => {
   const markerEl = marker.getElement();
   const { top, right, bottom, left } = markerEl.getBoundingClientRect();
   // find center of marker
-  // TODO: check entire rectangle instead
-  const markerX = left + Math.round(right - left) / 2;
-  const markerY = top + Math.round(bottom - top) / 2;
+  const [cX, cY] = [
+    left + Math.round(right - left) / 2,
+    top + Math.round(bottom - top) / 2,
+  ];
 
-  const topEl = document.elementFromPoint(markerX, markerY);
+  // assume points on top, bottom, right, left edges are within the bounding rect and test what the topmost element is at each point
+  const topEls = [
+    [cX, top + 1],
+    [right - 1, cY],
+    [cX, bottom - 1],
+    [left + 1, cY],
+  ].map(([x, y]) => document.elementFromPoint(x, y));
 
-  const isOnTop = markerEl.isSameNode(topEl);
+  // determine if all chosen marker points are visible
+  const isOnTop = topEls.reduce((acc, topEl) => {
+    return acc && markerEl.isSameNode(topEl);
+  }, true);
 
   return isInsideMap && isOnTop;
 };
@@ -52,6 +62,7 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
     isSelected: boolean,
   ) => {
     const element = marker.getElement();
+
     if (isSelected) {
       element.className =
         "marker-selected mapboxgl-marker mapboxgl-marker-anchor-center";

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -9,6 +9,15 @@ type MapboxMapProps = {
   schools: School[];
 };
 
+const isVisible = (marker: mapboxgl.Marker, map: mapboxgl.Map) => {
+  // check if marker within bounds of map
+  const lngLat = marker.getLngLat();
+  const bounds = map.getBounds();
+  const isInsideMap = bounds.contains(lngLat);
+
+  return isInsideMap;
+};
+
 const MapboxMap = ({ schools }: MapboxMapProps) => {
   const { selectedSchool, setSelectedSchool } = useMapContext();
   const mapContainer = useRef<HTMLDivElement | null>(null);
@@ -157,10 +166,9 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
             }
 
             const lngLat = schoolMarker.getLngLat();
-            const bounds = map.getBounds();
 
             // if we have focused on a school outside of the bounds of the map, recenter (e.g., for keyboard navigation)
-            if (!bounds.contains(lngLat)) {
+            if (!isVisible(schoolMarker, map)) {
               // pan to school marker
               map.flyTo({
                 center: [lngLat.lng, lngLat.lat],
@@ -196,7 +204,7 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
         mapRef.current = null;
       }
     };
-  }, [schools, setSelectedSchool]);
+  }, [schools, setSelectedSchool, flyToOptions]);
 
   // Update marker appearance when selectedSchool changes and map is loaded
   useEffect(() => {
@@ -214,10 +222,8 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
         if (!userHasInteracted.current) {
           // Use jumpTo when returning from detail page. it's less dizzying.
 
-          const bounds = mapRef.current.getBounds();
-
           // if we have focused on a school outside of the bounds of the map, recenter
-          if (!bounds.contains(lngLat)) {
+          if (!isVisible(selectedMarker, mapRef.current)) {
             // jump to marker
             mapRef.current.jumpTo({
               center: [lngLat.lng, lngLat.lat],
@@ -227,10 +233,8 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
         } else {
           // Use flyTo for all other cases
 
-          const bounds = mapRef.current.getBounds();
-
           // if we have focused on a school outside of the bounds of the map, recenter
-          if (!bounds.contains(lngLat)) {
+          if (!isVisible(selectedMarker, mapRef.current)) {
             // pan to marker
             mapRef.current.flyTo({
               center: [lngLat.lng, lngLat.lat],

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -64,7 +64,7 @@ h6 * {
   border-radius: 0;
   cursor: pointer;
   outline: none;
-  z-index: 10;
+  z-index: 5;
 }
 
 .golden-gate-marker {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -64,6 +64,7 @@ h6 * {
   border-radius: 0;
   cursor: pointer;
   outline: none;
+  z-index: 10;
 }
 
 .golden-gate-marker {


### PR DESCRIPTION
This PR addresses the issue where a map marker could be overlapped by the school details pane that overlaps the map on mobile. We now attempt to detect if the selected map marker (school) is obscured and center it if so.

Closes #265 