### PR TITLE
added close icon to desktop school card allowing user to deselect from the card itself

### DIFF
--- a/src/components/SchoolCardMap.tsx
+++ b/src/components/SchoolCardMap.tsx
@@ -70,7 +70,7 @@ const SchoolCard: React.FC<SchoolCardProps> = ({
     >
       <button
         onClick={onClose}
-        className="absolute left-2 top-2 z-10 block md:hidden"
+        className="absolute left-2 top-2 z-10 block md:relative md:top-8"
       >
         <Image
           src={`/circle_close.svg`}


### PR DESCRIPTION
reusing logic from the "mobile" version. Only tested on one desktop screen resolution. Could use some additional testing on alternative dimensions.