### PR TITLE
Enable ZIP Code Search

### DIFF
--- a/prisma/migrations/20240522184551_/migration.sql
+++ b/prisma/migrations/20240522184551_/migration.sql
@@ -14,6 +14,7 @@ CREATE TABLE "School" (
     "img" TEXT,
     "latitude" TEXT NOT NULL,
     "longitude" TEXT NOT NULL,
+    "zipcode" TEXT,
 
     CONSTRAINT "School_pkey" PRIMARY KEY ("id")
 );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model School {
   profile            SchoolProfile?
   metrics            Metric[]
   programs           Program[]
+  zipcode            String?
 }
 
 model SchoolProfile {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,10 +18,11 @@ model School {
   img                String?
   latitude           String
   longitude          String
+  zipcode            String?
   profile            SchoolProfile?
   metrics            Metric[]
   programs           Program[]
-  zipcode            String?
+ 
 }
 
 model SchoolProfile {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,6 +11,7 @@ async function main() {
       img: "balboa.jpeg",
       latitude: "37.722",
       longitude: "-122.44041",
+      zipcode: "94112",
       profile: {
         create: {
           about: `Balboa ("Bal") is a unique high school with a rich history and tradition.`,
@@ -136,6 +137,7 @@ async function main() {
       img: "burton.jpeg",
       latitude: "37.72126",
       longitude: "-122.4063",
+      zipcode: "94134",
       profile: {
         create: {
           about: `Burton High School was established in 1984 as a result of a Consent Decree between the City of San Francisco and the NAACP, and is named after Phillip Burton, a member of the California Assembly who championed the civil rights of others. Burton also:`,
@@ -269,6 +271,7 @@ async function main() {
       img: "downtown.jpeg",
       latitude: "37.761565",
       longitude: "-122.40394",
+      zipcode: "94107",
       profile: {
         create: {
           about: `Downtown High School (DHS) is one of two continuation schools in SFUSD, dedicated to serving students whose success was limited in the district's comprehensive and charter high schools.`,
@@ -384,6 +387,7 @@ async function main() {
       img: "galileo.jpeg",
       latitude: "37.80379",
       longitude: "-122.424145",
+      zipcode: "94109",
       profile: {
         create: {
           about: `Galileo Academy of Science and Technology ("Galileo") is committed to providing equal access to all of their educational programs.`,
@@ -502,6 +506,7 @@ async function main() {
       img: "idabwells.jpeg",
       latitude: "37.7751",
       longitude: "-122.433985",
+      zipcode: "94117",
       profile: {
         create: {
           about: `Ida B. Wells (IBW) is one of two continuation schools in SFUSD, dedicated to serving students whose success was limited in the district's comprehensive and charter high schools.`,
@@ -615,6 +620,7 @@ async function main() {
       img: "independence.jpeg",
       latitude: "37.76309",
       longitude: "-122.46388",
+      zipcode: "94122",
       profile: {
         create: {
           about: `Independence is a small alternative high school in SFUSD.`,
@@ -726,6 +732,7 @@ async function main() {
       img: "international.jpeg",
       latitude: "37.76169",
       longitude: "-122.40082",
+      zipcode: "94107",
       profile: {
         create: {
           about: `SF International is a small public high school that offers a unique program designed for recent immigrant students.`,
@@ -836,6 +843,7 @@ async function main() {
       img: "junejordan.jpeg",
       latitude: "37.7195",
       longitude: "-122.42539",
+      zipcode: "94112",
       profile: {
         create: {
           about: `June Jordan is a small alternative high school named after activist June Jordan. The school was founded through community organizing by a group of teachers, parents, and youth.`,
@@ -943,6 +951,7 @@ async function main() {
       img: "lincoln.jpeg",
       latitude: "37.74729",
       longitude: "-122.48109",
+      zipcode: "94116",
       profile: {
         create: {
           about: `Lincoln is one of the three largest high schools in SFUSD. The school features:`,
@@ -1070,6 +1079,7 @@ async function main() {
       img: "lowell.jpeg",
       latitude: "37.73068",
       longitude: "-122.48392",
+      zipcode: "94132",
       profile: {
         create: {
           about: `Established in 1856, Lowell High School is the oldest public high school west of Mississippi, recognized as one of California's highest-performing public high scools.`,
@@ -1186,6 +1196,7 @@ async function main() {
       img: "mission.jpeg",
       latitude: "37.7616",
       longitude: "-122.42698",
+      zipcode: "94114",
       profile: {
         create: {
           about: `Mission High is the oldest comprehensive public school in San Francisco founded in 1890. The school:`,
@@ -1303,6 +1314,7 @@ async function main() {
       img: "johnoconnell.jpeg",
       latitude: "37.75956",
       longitude: "-122.41454",
+      zipcode: "94110",
       profile: {
         create: {
           about: `JOCHS is a small, academic-focused high school with several career pathways. The school provides:`,
@@ -1418,6 +1430,7 @@ async function main() {
       img: "ruthasawa.jpeg",
       latitude: "37.74538",
       longitude: "-122.44965",
+      zipcode: "94131",
       profile: {
         create: {
           about: `Ruth Asawa School of the Arts (SOTA) is named after renowned sculptor Ruth Asawa who was a passionate advocate for arts in education.`,
@@ -1536,6 +1549,7 @@ async function main() {
       img: "theacademy.jpeg",
       latitude: "37.745499",
       longitude: "-122.451563",
+      zipcode: "94131",
       profile: {
         create: {
           about: `The Academy fosters one of the smallest school learning environments, where teachers can closely engage with students, hands-on administrators, and families for a stronger, supportive community.`,
@@ -1652,6 +1666,7 @@ async function main() {
       img: "thurgood.jpeg",
       latitude: "37.73609",
       longitude: "-122.40211",
+      zipcode: "94124",
       profile: {
         create: {
           about: `Thurgood Marshall High School was founded in 1994, and is located in the southeastern part of San Francisco. The school offers:`,
@@ -1771,6 +1786,7 @@ async function main() {
       img: "wallenberg.jpeg",
       latitude: "37.780365",
       longitude: "-122.44621",
+      zipcode: "94115",
       profile: {
         create: {
           about: `Founded in 1981, the Raoul Wallenberg Traditional High School (or "Wallenberg") honors the renowned Swedist diplomat, guided by personal responsibility, compassion, honesty, and integrity for equitable educational outcomes that enhance creativity, self-discipline, and citizenship.`,
@@ -1897,6 +1913,7 @@ async function main() {
       img: "washington.jpeg",
       latitude: "37.77784",
       longitude: "-122.49174",
+      zipcode: "94121",
       profile: {
         create: {
           about: `Washington is one of the largest high schools in SFUSD, opened in 1936.`,

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { MetricCategory, PrismaClient, ProgramCategory } from "@prisma/client";
 const prisma = new PrismaClient();
+
 async function main() {
   const schools = [
     // Balboa

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -43,7 +43,7 @@ export default function SearchBar<DropdownItemType = any>({
       </div>
       <input
         type="text"
-        placeholder="Search your school here..."
+        placeholder="Search by Zip Code or School Name..."
         value={searchTerm}
         className="h-[38px] w-full rounded-lg border border-black p-1 px-4 py-2 pl-12 shadow-lg focus:border-blue-400"
         onChange={onInputChange}

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -62,8 +62,10 @@ const Map: React.FC<Props> = (props) => {
 
   const handleSchoolSearch = async (searchTerm: string) => {
     return props.schools
-      .filter(({ name }) =>
-        name.toUpperCase().includes(searchTerm.toUpperCase()),
+      .filter(
+        ({ name, zipcode }) =>
+          name.toUpperCase().includes(searchTerm.toUpperCase()) ||
+          zipcode?.includes(searchTerm),
       )
       .map((school) => ({
         label: school.name,

--- a/src/types/school.ts
+++ b/src/types/school.ts
@@ -10,6 +10,7 @@ export interface School {
   profile?: SchoolProfile;
   metrics: Metric[];
   programs: Program[];
+  zipcode?: string;
 }
 
 export interface SchoolProfile {


### PR DESCRIPTION
Add a new feature to the search bar, allowing users to search for school by ZIP code.

**Key improvements:**

- Enhanced User Experience: Provides a more flexible and convenient way to search.
- Improved Search Functionality: Expands the search capabilities of the application.

**Testing Steps / QA Criteria:**

- Navigate to the zip-code-search-bar branch.
- On a map page, enter a ZIP code in the search bar. Example: 94134
- Verify that schools appear in a dropdown.
- Switch to the list view and repeat the same steps.


