### PR TITLE
Enable searching by neighborhood

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -43,7 +43,7 @@ export default function SearchBar<DropdownItemType = any>({
       </div>
       <input
         type="text"
-        placeholder="Search by Zip Code or School Name..."
+        placeholder="Type school name, zip code, or neighborhood"
         value={searchTerm}
         className="h-[38px] w-full rounded-lg border border-black p-1 px-4 py-2 pl-12 shadow-lg focus:border-blue-400"
         onChange={onInputChange}

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -61,12 +61,17 @@ const Map: React.FC<Props> = (props) => {
   };
 
   const handleSchoolSearch = async (searchTerm: string) => {
+    const searchTermToLowerCase = searchTerm.toLowerCase();
     return props.schools
-      .filter(
-        ({ name, zipcode }) =>
-          name.toUpperCase().includes(searchTerm.toUpperCase()) ||
-          zipcode?.includes(searchTerm),
-      )
+      .filter(({ name, zipcode, neighborhood }) => {
+        const nameToLowerCase = name.toLowerCase();
+        const neighborhoodToLowerCase = neighborhood?.toLowerCase();
+        return (
+          nameToLowerCase.includes(searchTermToLowerCase) ||
+          zipcode?.includes(searchTermToLowerCase) ||
+          neighborhoodToLowerCase?.includes(searchTermToLowerCase)
+        );
+      })
       .map((school) => ({
         label: school.name,
         value: school.name,


### PR DESCRIPTION
Description: Add the ability to search for schools by neighborhood in addition to the existing search capabilities.

Key Improvements:

- Supports searching for schools by the neighborhood in which they are located

- Ensures that the search functionality works correctly regardless of whether the user enters the search term in lowercase or uppercase.


Testing Steps / QA Criteria:

- Navigate to the search-neighborhood branch.
- On the map page, enter a neighborhood name in the search bar.  Example: "Excelsior".  Expected output: 'Balboa High School and June Jordan School for Equity. 
- Verify that schools in the specified neighborhood appear in the dropdown.
- Switch to the list view and repeat the same steps to ensure consistency across views.

Closes issue #282
