### PR TITLE
Add persistence for Selected School Type 

### DIFF
--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -43,7 +43,7 @@ const Map: React.FC<Props> = (props) => {
   );
   const [filteredSchools, setFilteredSchools] = useState(props.schools);
   useEffect(() => {
-    const storedTypes = localStorage.getItem("selectedSchoolTypes");
+    const storedTypes = sessionStorage.getItem("selectedSchoolTypes");
     if (storedTypes) {
       setSelectedSchoolTypes(JSON.parse(storedTypes) as SchoolType[]);
     }
@@ -80,7 +80,7 @@ const Map: React.FC<Props> = (props) => {
 
     setSelectedSchoolTypes(updatedTypes);
 
-    localStorage.setItem("selectedSchoolTypes", JSON.stringify(updatedTypes));
+    sessionStorage.setItem("selectedSchoolTypes", JSON.stringify(updatedTypes));
   };
 
   const getSchoolsByType = (schoolTypes: SchoolType[], schools: School[]) => {

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -69,16 +69,13 @@ const Map: React.FC<Props> = (props) => {
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const value = e.target.value as SchoolType;
-    if (!selectedSchoolTypes.includes(value)) {
-      const selectedTypes = [...selectedSchoolTypes, value];
+    const updatedTypes = selectedSchoolTypes.includes(value)
+      ? selectedSchoolTypes.filter((type) => type !== value)
+      : [...selectedSchoolTypes, value];
 
-      setSelectedSchoolTypes(selectedTypes);
-    } else {
-      const selectedType = selectedSchoolTypes.filter(
-        (element) => element !== value,
-      );
-      setSelectedSchoolTypes(selectedType);
-    }
+    setSelectedSchoolTypes(updatedTypes);
+
+    localStorage.setItem("selectedSchoolTypes", JSON.stringify(updatedTypes));
   };
 
   const getSchoolsByType = (schoolTypes: SchoolType[], schools: School[]) => {

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -42,7 +42,12 @@ const Map: React.FC<Props> = (props) => {
     [],
   );
   const [filteredSchools, setFilteredSchools] = useState(props.schools);
-
+  useEffect(() => {
+    const storedTypes = localStorage.getItem("selectedSchoolTypes");
+    if (storedTypes) {
+      setSelectedSchoolTypes(JSON.parse(storedTypes) as SchoolType[]);
+    }
+  }, []);
   useEffect(() => {
     setFilteredSchools(getSchoolsByType(selectedSchoolTypes, props.schools));
   }, [selectedSchoolTypes, props.schools]);


### PR DESCRIPTION

**Description:** 

This pull request enhances the school type filter functionality by implementing session storage. This ensures a smoother user experience as selected filters will now persist when users navigate between pages or reload the page within the same browser tab or window.

The filter state will automatically reset when the browser tab or window is closed, providing a fresh session for new users. 


**Testing Steps:**

- Run the project and navigate to the browser.
- Select one or more school types.
- Verify that the selected school types persist when navigating between pages within the same tab or window.
- Reload the page and confirm that the filter state is retained.
- Close the browser tab or window and reopen the page.
- Verify that the filter state resets after the session ends.