### PR TITLE
Add Priority checkbox with logic, persistence, and styling

### DIFF
--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -42,6 +42,8 @@ const Map: React.FC<Props> = (props) => {
     [],
   );
   const [filteredSchools, setFilteredSchools] = useState(props.schools);
+  const [priorityFilter, setPriorityFilter] = useState(false);
+
   useEffect(() => {
     const storedTypes = sessionStorage.getItem("selectedSchoolTypes");
     if (storedTypes) {
@@ -49,8 +51,10 @@ const Map: React.FC<Props> = (props) => {
     }
   }, []);
   useEffect(() => {
-    setFilteredSchools(getSchoolsByType(selectedSchoolTypes, props.schools));
-  }, [selectedSchoolTypes, props.schools]);
+    setFilteredSchools(
+      getSchoolsByType(selectedSchoolTypes, props.schools, priorityFilter),
+    );
+  }, [selectedSchoolTypes, props.schools, priorityFilter]);
 
   const openModal = () => {
     setModalIsOpen(true);
@@ -83,14 +87,21 @@ const Map: React.FC<Props> = (props) => {
     sessionStorage.setItem("selectedSchoolTypes", JSON.stringify(updatedTypes));
   };
 
-  const getSchoolsByType = (schoolTypes: SchoolType[], schools: School[]) => {
+  const getSchoolsByType = (
+    schoolTypes: SchoolType[],
+    schools: School[],
+    priorityFilter: boolean,
+  ) => {
     if (schoolTypes.length === 0) {
       return schools;
     }
-
     return schools.filter((school) => {
-      const schoolTypeSet = new Set(school.school_type);
-      return schoolTypes.some((schoolType) => schoolTypeSet.has(schoolType));
+      const matchesSchoolType =
+        schoolTypes.length === 0 ||
+        schoolTypes.some((type) => school.school_type.includes(type));
+      const matchesPriority = !priorityFilter || school.priority === true;
+
+      return matchesSchoolType && matchesPriority;
     });
   };
 
@@ -237,6 +248,15 @@ const Map: React.FC<Props> = (props) => {
                   selectedSchoolTypes={selectedSchoolTypes}
                   setSelectedSchoolTypes={setSelectedSchoolTypes}
                   handleSchoolTypeSelection={handleSchoolTypeSelection}
+                />
+                <label>Priority</label>
+                <input
+                  type="checkbox"
+                  id="priority"
+                  name="priority"
+                  onChange={(e) => setPriorityFilter(e.target.checked)}
+                  checked={priorityFilter}
+                  className="border-black bg-transparent"
                 />
               </div>
 

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -270,6 +270,11 @@ const Map: React.FC<Props> = (props) => {
                     src="/circle_priority.svg"
                     width={19}
                     height={20}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setModalIsOpen(true);
+                    }}
+                    className="w-fit"
                   ></Image>
                   <label>Priority</label>
                   <input

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -258,21 +258,29 @@ const Map: React.FC<Props> = (props) => {
                 />
               </div>
 
-              <div>
+              <div className="flex items-center justify-between gap-4">
                 <FilterBySchoolType
                   selectedSchoolTypes={selectedSchoolTypes}
                   setSelectedSchoolTypes={setSelectedSchoolTypes}
                   handleSchoolTypeSelection={handleSchoolTypeSelection}
                 />
-                <label>Priority</label>
-                <input
-                  type="checkbox"
-                  id="priority"
-                  name="priority"
-                  onChange={handlePriorityChange}
-                  checked={priorityFilter}
-                  className="border-black bg-transparent"
-                />
+                <div className="flex items-center justify-between gap-2">
+                  <Image
+                    alt="High priority icon"
+                    src="/circle_priority.svg"
+                    width={19}
+                    height={20}
+                  ></Image>
+                  <label>Priority</label>
+                  <input
+                    type="checkbox"
+                    id="priority"
+                    name="priority"
+                    onChange={handlePriorityChange}
+                    checked={priorityFilter}
+                    className="border-black bg-transparent accent-orange-500"
+                  />
+                </div>
               </div>
 
               {isMapView ? (

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -46,15 +46,27 @@ const Map: React.FC<Props> = (props) => {
 
   useEffect(() => {
     const storedTypes = sessionStorage.getItem("selectedSchoolTypes");
+    const storedPriority = sessionStorage.getItem("priorityFilter");
     if (storedTypes) {
       setSelectedSchoolTypes(JSON.parse(storedTypes) as SchoolType[]);
     }
+    if (storedPriority) {
+      setPriorityFilter(JSON.parse(storedPriority));
+    }
   }, []);
+
   useEffect(() => {
     setFilteredSchools(
       getSchoolsByType(selectedSchoolTypes, props.schools, priorityFilter),
     );
   }, [selectedSchoolTypes, props.schools, priorityFilter]);
+
+  useEffect(() => {
+    const storedPriority = sessionStorage.getItem("priorityFilter");
+    if (storedPriority) {
+      setPriorityFilter(JSON.parse(storedPriority));
+    }
+  }, []);
 
   const openModal = () => {
     setModalIsOpen(true);
@@ -100,6 +112,12 @@ const Map: React.FC<Props> = (props) => {
 
       return matchesSchoolType && matchesPriority;
     });
+  };
+
+  const handlePriorityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const isChecked = e.target.checked;
+    setPriorityFilter(isChecked);
+    sessionStorage.setItem("priorityFilter", JSON.stringify(isChecked));
   };
 
   const handleSchoolSearch = async (searchTerm: string) => {
@@ -251,7 +269,7 @@ const Map: React.FC<Props> = (props) => {
                   type="checkbox"
                   id="priority"
                   name="priority"
-                  onChange={(e) => setPriorityFilter(e.target.checked)}
+                  onChange={handlePriorityChange}
                   checked={priorityFilter}
                   className="border-black bg-transparent"
                 />

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -92,9 +92,6 @@ const Map: React.FC<Props> = (props) => {
     schools: School[],
     priorityFilter: boolean,
   ) => {
-    if (schoolTypes.length === 0) {
-      return schools;
-    }
     return schools.filter((school) => {
       const matchesSchoolType =
         schoolTypes.length === 0 ||


### PR DESCRIPTION

### **Description**:

Implemented **Priority Checkbox** feature to the project, enhancing the filtering functionality. The changes include the addition of the checkbox, updates to the filtering logic, persistence across navigation using session storage, and styling improvements for the priority checkbox section.

---

### **Changes Made**:
- Added a checkbox labeled "Priority" to allow users to filter schools based on their priority status (`priority: true`).
- Enhanced the filtering logic to combine school type filtering with priority filtering. When the priority checkbox is checked, only schools with `priority: true` are displayed.
- Implemented session storage to persist the state of the priority checkbox across navigation. 
- Styled the priority checkbox section using Tailwind CSS.

**Before:**
<img width="1191" alt="Screenshot 2025-06-26 at 4 01 22 PM" src="https://github.com/user-attachments/assets/9d87a987-b8b8-4e0c-b4de-6624eb086f0c" />

**After:** 

<img width="1059" alt="Screenshot 2025-06-26 at 3 51 56 PM" src="https://github.com/user-attachments/assets/33f55e5f-8f72-4487-a14d-e57053c55252" />

<img width="1060" alt="Screenshot 2025-06-26 at 3 51 46 PM" src="https://github.com/user-attachments/assets/146ff028-b57b-4937-9bd6-1bcf1f0ab5e0" />


---
### **Testing Steps**:

1. Run the project and navigate to the browser.
2. Select a school type (e.g., high) and enable the priority checkbox.
3. Verify that only schools with `priority: true` and the selected school type are displayed.
4. Navigate to another page and return to the main page.
5. Verify that the priority checkbox state is restored correctly.
6. Verify that the priority filter resets after the session ends.

---

### Note:

1. When "Show All" is selected, the system **automatically** resets the type filters, but the priority checkbox **remains active**. 
2. This section will require additional **styling**, which will be completed during the redesign phase, following the new designs provided by the designers.
3. Right now, only some schools from **high schools** have 'Priority' set to true.