### PR TITLE
edit map copy for summer on main

### DIFF
--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -29,7 +29,7 @@ type Props = {
 
 const schoolCardPlaceholderTitle = "Select a School";
 const schoolCardPlaceholderText =
-  "All schools are looking for volunteers and donations. Click on the school closest to you to learn more.";
+  "San Francisco public schools are closed until mid August. Click on the school closest to you to learn about opportunities in the fall.";
 
 const Map: React.FC<Props> = (props) => {
   const { isMapView, selectedSchool, setIsMapView, setSelectedSchool } =


### PR DESCRIPTION
closes [#326](https://github.com/sfbrigade/support-sfusd/issues/326) 

## Changes
Updated Map default text to say "San Francisco public schools are closed until mid August. Click on the school closest to you to learn about opportunities in the fall."

<img width="1397" height="528" alt="map-copy-edit" src="https://github.com/user-attachments/assets/144a469b-16bb-4681-a9c3-88fef4e8fce3" />


## New
<img width="250" height="333" alt="new-map-copy" src="https://github.com/user-attachments/assets/ca72acb5-a107-464a-8d8d-cb62ec01a828" />



## Old
<img width="250" height="338" alt="old-map-copy" src="https://github.com/user-attachments/assets/bc3eae0e-eb1e-4892-998f-c1c9272f4b03" />