### PR TITLE
Lower z-index of navbar and map to fix modal visibility

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -34,7 +34,7 @@ const Navbar = () => {
     router.events.on("routeChangeComplete", handleRouteChange);
   }, [router]);
   return (
-    <nav className={"sticky top-0 z-50 w-full p-2 p-4 px-4 text-black " + bg}>
+    <nav className={"sticky top-0 z-40 w-full p-2 p-4 px-4 text-black " + bg}>
       <div className="container mx-auto max-w-[1280px] font-medium">
         <div className="flex items-center justify-between">
           {/* Home Icon */}

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -182,7 +182,7 @@ const Map: React.FC<Props> = (props) => {
           <div className="flex h-full w-full grid-cols-10 flex-row-reverse items-center justify-center gap-4 md:grid md:w-auto md:flex-col">
             {/* School Card or Placeholder */}
             <div
-              className={`col-span-4 ${isMapView && selectedSchool ? "p-0" : "p-2 md:p-0"}  ${isMapView && selectedSchool !== null ? "flex" : "hidden"} absolute bottom-0 left-0 right-0 z-50 m-4 flex h-fit items-center justify-center rounded-2xl bg-white md:static md:m-0 md:flex md:h-full`}
+              className={`col-span-4 ${isMapView && selectedSchool ? "p-0" : "p-2 md:p-0"}  ${isMapView && selectedSchool !== null ? "flex" : "hidden"} absolute bottom-0 left-0 right-0 z-40 m-4 flex h-fit items-center justify-center rounded-2xl bg-white md:static md:m-0 md:flex md:h-full`}
             >
               {isMapView ? (
                 selectedSchool ? (


### PR DESCRIPTION
The z-index of the navbar and map has been lowered to ensure that the beta feedback model is displayed correctly above them. This change addresses the issue of the modal being obscured by the navbar.

Fixes #334