### PR TITLE
feature/search dropdown keyboard accessibility

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,25 +1,42 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { DropdownItem } from "./SearchBar";
 
 interface DropdownProps<ItemType> {
   items: DropdownItem<ItemType>[];
   onItemSelect: (item: DropdownItem<ItemType>) => void;
+  cursor: number;
 }
 
 export default function Dropdown<ItemType = any>({
   items,
   onItemSelect,
+  cursor
 }: DropdownProps<ItemType>): JSX.Element {
+
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (cursor >= 0 && listRef.current) {
+      const selectedElement = listRef.current.children[cursor] as HTMLElement;
+      if (selectedElement) {
+        selectedElement.scrollIntoView({
+          block: 'nearest',
+          behavior: 'smooth'
+        });
+      }
+    }
+  }, [cursor])
+
   return (
     <>
       <div
         className={`top-30 absolute z-30 flex max-h-[300px] w-full cursor-pointer flex-col overflow-auto rounded-lg bg-slate-100 shadow-lg`}
       >
-        <ul>
-          {items.map((item) => (
+        <ul ref={listRef}>
+          {items.map((item, index) => (
             <li
               key={item.value}
-              className="px-4 py-2 hover:bg-zinc-300"
+              className={`px-4 py-2 hover:bg-zinc-300 ${cursor === index ? 'bg-zinc-300' : ''}`}
               onClick={() => onItemSelect(item)}
             >
               {item.label}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -27,6 +27,7 @@ export default function SearchBar<DropdownItemType = any>({
     setSearchTerm(userInput);
     const searchResults = await onSearch(userInput);
     setDropdownItems(searchResults);
+    setCursor(-1);
   };
 
   const handleItemSelect = (item: DropdownItem<DropdownItemType>) => {
@@ -70,13 +71,28 @@ export default function SearchBar<DropdownItemType = any>({
         value={searchTerm}
         className="placeholder-small h-[38px] w-full rounded-lg border border-black p-1 px-4 py-2 pl-12 shadow-lg focus:border-blue-400"
         onChange={onInputChange}
-        onFocus={() => setSearchTerm("")}
+        onFocus={() => 
+          {
+            if (searchTerm.length > 0) {
+              // Re-trigger search to show dropdown
+              onSearch(searchTerm).then(setDropdownItems);
+            }
+          }
+        }
+        onBlur={() => 
+          {
+            // Hide dropdown when input loses focus
+            setDropdownItems([]);
+            setCursor(-1);
+          }
+        }
         onKeyDown={handleKeyDown}
       />
-      {dropdownItems.length > 0 && searchTerm.length > 0 && (
+      {dropdownItems.length > 0 && (
         <Dropdown
           items={dropdownItems}
           onItemSelect={handleItemSelect}
+          cursor={cursor}
         />
       )}
     </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -19,9 +19,8 @@ export default function SearchBar<DropdownItemType = any>({
   onSearch,
 }: SearchBarProps<DropdownItemType>): JSX.Element {
   const [searchTerm, setSearchTerm] = useState("");
-  const [dropdownItems, setDropdownItems] = useState<
-    DropdownItem<DropdownItemType>[]
-  >([]);
+  const [dropdownItems, setDropdownItems] = useState<DropdownItem<DropdownItemType>[]>([]);
+  const [cursor, setCursor] = useState(-1);
 
   const onInputChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const userInput = e.target.value;
@@ -36,6 +35,30 @@ export default function SearchBar<DropdownItemType = any>({
     setDropdownItems([]);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Does not handle keys if dropdown is empty
+    if (dropdownItems.length === 0) {
+      return
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setCursor(prev => 
+        prev < dropdownItems.length - 1 ? prev + 1 : prev
+      )
+    }
+    else if (e.key === "ArrowUp"){
+      e.preventDefault();
+      setCursor(prev => 
+        prev > 0 ? prev - 1 : prev
+      )
+    }
+    else if (e.key === "Enter" && cursor >= 0) {
+      e.preventDefault();
+      handleItemSelect(dropdownItems[cursor]);
+    }
+  };
+
   return (
     <div className="relative flex-grow">
       <div className="pointer-events-none absolute inset-y-0 left-4 flex items-center">
@@ -48,9 +71,13 @@ export default function SearchBar<DropdownItemType = any>({
         className="placeholder-small h-[38px] w-full rounded-lg border border-black p-1 px-4 py-2 pl-12 shadow-lg focus:border-blue-400"
         onChange={onInputChange}
         onFocus={() => setSearchTerm("")}
+        onKeyDown={handleKeyDown}
       />
       {dropdownItems.length > 0 && searchTerm.length > 0 && (
-        <Dropdown items={dropdownItems} onItemSelect={handleItemSelect} />
+        <Dropdown
+          items={dropdownItems}
+          onItemSelect={handleItemSelect}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Related Issue
Closes [#253](https://github.com/sfbrigade/support-sfusd/issues/253)

## Problem
The dropdown menus are not fully keyboard accessible.
Users should be able to navigate through the options using the arrow keys and select a school by pressing the 'Enter' key.

## Solution
- Added up/down/enter keyboard navigation to SearchBar dropdown items for better accessibility
- Add UI to reflect selection from arrow navigation