### PR TITLE
[About us page] Update the text to fix the space between words

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -165,7 +165,7 @@ const About = () => {
                 connecting people with their local schools. Following a
                 community schools model, people who live near a school can
                 {
-                  "support and be part of the school community, even if they aren't parents of current students. "
+                  " support and be part of the school community, even if they aren't parents of current students. "
                 }
                 We have talked to hundreds of people who live in San Francisco,
                 who are willing to volunteer and support local schools, and who
@@ -178,9 +178,8 @@ const About = () => {
               <p>
                 This website is in beta and is a work in progress. We are open
                 to feedback and always looking for volunteers to join our
-                effort.
+                effort. We meet Wednesday evenings on Zoom.
               </p>
-              <p>We meet Wednesday evenings on Zoom.</p>
             </div>
 
             <h2 className="text-xl font-semibold text-[#272728]">Team:</h2>


### PR DESCRIPTION
**Description:**

This PR fixes the following:

- Typo in the second paragraph where "cansupport" is one word instead of two?
- Move the last sentence "We meet Wednesday evenings on Zoom" to the end of the third paragraph, instead of its own. 

**Testing Steps**

- [ ] Pull this branch and run the project locally.
- [ ] Navigate to the About page in your browser to review changes.
- [ ] Verify all links works as expected