### PR TITLE
Refactor/priority-filter-flag

### DIFF
--- a/src/components/FilterBySchoolType.tsx
+++ b/src/components/FilterBySchoolType.tsx
@@ -9,6 +9,7 @@ interface FilterBySchoolTypeProps {
   setModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handlePriorityChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   priorityFilter: boolean;
+  setPriorityFilter: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const schoolTypes = [
@@ -24,6 +25,7 @@ export default function FilterBySchoolType({
   setModalIsOpen,
   handlePriorityChange,
   priorityFilter,
+  setPriorityFilter,
 }: FilterBySchoolTypeProps) {
   return (
     <div className="flex flex-col flex-wrap justify-between gap-4 md:mt-4 md:flex-row">
@@ -35,8 +37,8 @@ export default function FilterBySchoolType({
             id="all"
             name="all"
             value="all"
-            onChange={() => setSelectedSchoolTypes([])}
-            checked={selectedSchoolTypes.length === 0}
+            onChange={() => { setSelectedSchoolTypes([]); setPriorityFilter(false); }}
+            checked={selectedSchoolTypes.length === 0 && !priorityFilter}
             className="accent-[#3A86FF]"
           />
         </div>
@@ -91,7 +93,7 @@ export default function FilterBySchoolType({
         </div>
       </div>
 
-      <div className="hidden md:flex items-center gap-2">
+      <div className="hidden items-center gap-2 md:flex">
         <Image
           alt="High priority icon"
           src="/circle_priority.svg"

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -138,10 +138,7 @@ const Map: React.FC<Props> = (props) => {
     const isChecked = e.target.checked;
     setPriorityFilter(isChecked);
     sessionStorage.setItem("priorityFilter", JSON.stringify(isChecked));
-    if (isChecked) {
-      setSelectedSchoolTypes([]); // Unselect "Show All"
-      sessionStorage.setItem("selectedSchoolTypes", JSON.stringify([]));
-    }
+    
   };
 
   const handleSchoolSearch = async (searchTerm: string) => {
@@ -261,6 +258,7 @@ const Map: React.FC<Props> = (props) => {
                   setModalIsOpen={setModalIsOpen}
                   handlePriorityChange={handlePriorityChange}
                   priorityFilter={priorityFilter}
+                  setPriorityFilter={setPriorityFilter}
                 />
               </div>
             </div>
@@ -387,6 +385,7 @@ const Map: React.FC<Props> = (props) => {
                   setModalIsOpen={setModalIsOpen}
                   handlePriorityChange={handlePriorityChange}
                   priorityFilter={priorityFilter}
+                  setPriorityFilter={setPriorityFilter}
                 />
                 {/* <div className="flex items-center gap-2">
                     <Image


### PR DESCRIPTION
This PR moves the priority filter UI elements into the `FilterBySchoolType` component to improve interoperability between filter flags.
It also updates the flag interaction logic:

- Selecting *Select All* now deselects all other flags, including *Priority*.
- Selecting *Priority* automatically unsets *Select All*.

These changes were implemented with minimal modifications to the `map` page logic. However, the `map` page is growing increasingly complex and hard to maintain. It may be worth revisiting the overall design to identify opportunities to simplify by delegating more state and logic to child components.

Fixes #343