### PR TITLE
School stats appearance on About School page

### DIFF
--- a/src/components/schoolPageComponents/SchoolAbout.tsx
+++ b/src/components/schoolPageComponents/SchoolAbout.tsx
@@ -1,6 +1,5 @@
 import { School } from "@/types/school";
 import HeadingContentWrapper from "./HeadingContentWrapper";
-import Statistic from "./Statistic";
 import StatisticList from "./StatisticList";
 
 const SchoolAbout: React.FC<{ school: School }> = ({ school }) => {

--- a/src/components/schoolPageComponents/SchoolStudentOutcomes.tsx
+++ b/src/components/schoolPageComponents/SchoolStudentOutcomes.tsx
@@ -1,9 +1,8 @@
-import { School } from "@/types/school";
+import { Metric } from "@/types/school";
 import HeadingContentWrapper from "./HeadingContentWrapper";
 import StatisticList from "./StatisticList";
 
-const SchoolStudentOutcomes: React.FC<{ school: School }> = ({ school }) => {
-  const stats = school.metrics.filter((metric) => metric.category == "outcome");
+const SchoolStudentOutcomes: React.FC<{ stats: Metric[] }> = ({ stats }) => {
   return (
     <section id="StudentOutcomes">
       <HeadingContentWrapper

--- a/src/components/schoolPageComponents/StatisticList.tsx
+++ b/src/components/schoolPageComponents/StatisticList.tsx
@@ -1,12 +1,16 @@
+import { Metric } from "@/types/school";
 import Statistic from "./Statistic";
 
-const StatisticList = (props: any) => {
-  const { statistics } = props;
+interface StatisticListProps {
+  statistics: Metric[];
+}
+
+const StatisticList = ({ statistics }: StatisticListProps) => {
   return (
-    <div className=" flex flex-wrap gap-6 max-md:justify-center md:gap-12 ">
-      {statistics.map((stat: any) => (
+    <div className="flex flex-wrap gap-6 md:gap-12 ">
+      {statistics.map((stat) => (
         <Statistic
-          key={stat.text}
+          key={stat.name} // This is always unique within the array
           name={stat.name}
           value={stat.value}
           unit={stat.unit}

--- a/src/pages/school.tsx
+++ b/src/pages/school.tsx
@@ -1,12 +1,10 @@
-import BannerWrapper from "@/components/schoolPageComponents/BannerWrapper";
 import SchoolAbout from "@/components/schoolPageComponents/SchoolAbout";
 import SchoolDonation from "@/components/schoolPageComponents/SchoolDonation";
 import SchoolHeader from "@/components/schoolPageComponents/SchoolHeader";
 import SchoolStudentOutcomes from "@/components/schoolPageComponents/SchoolStudentOutcomes";
 import SchoolTestimonial from "@/components/schoolPageComponents/SchoolTestimonial";
 import SchoolVolunteer from "@/components/schoolPageComponents/SchoolVolunteer";
-import prisma from "@/lib/prisma";
-import { School } from "@/types/school";
+import { Metric, School } from "@/types/school";
 import { blurDataURL } from "@/lib/imageConfig";
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -20,38 +18,50 @@ const Profile: React.FC = () => {
   const [school, setSchool] = useState<School | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [studentOutcomes, setStudentOutcomes] = useState<Metric[]>([]);
 
   useEffect(() => {
-    if (stub && typeof stub === 'string') {
+    if (stub && typeof stub === "string") {
       setLoading(true);
       setError(null);
 
       fetch(`/api/school/${stub}`)
-      .then(res => {
-        if(!res.ok) {
-          throw new Error(res.status === 404 ? 'School not found' : 'Failed to load school');
-        }
-        return res.json();
-      })
-      .then(data => {
-        setSchool(data.school);
-        setLoading(false);
-      })
-      .catch(err => {
-        setError(err.message);
-        setLoading(false);
-      })
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(
+              res.status === 404 ? "School not found" : "Failed to load school",
+            );
+          }
+          return res.json();
+        })
+        .then((data) => {
+          setSchool(data.school);
+          setLoading(false);
+        })
+        .catch((err) => {
+          setError(err.message);
+          setLoading(false);
+        });
     } else {
-        setError('School stub is required');
-        setLoading(false);
+      setError("School stub is required");
+      setLoading(false);
     }
   }, [stub]);
 
+  useEffect(() => {
+    if (school) {
+      const studentSelectedStats = school.metrics?.filter(
+        ({ category }) => category === "outcome",
+      );
+      setStudentOutcomes(studentSelectedStats);
+    }
+  }, [school]);
+
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-blue-600"></div>
           <p className="text-gray-600">Loading school information...</p>
         </div>
       </div>
@@ -60,13 +70,13 @@ const Profile: React.FC = () => {
 
   if (error) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-red-600 mb-2">Error</h1>
+          <h1 className="mb-2 text-2xl font-bold text-red-600">Error</h1>
           <p className="text-gray-600">{error}</p>
-          <button 
+          <button
             onClick={() => router.back()}
-            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="mt-4 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
           >
             Go Back
           </button>
@@ -77,13 +87,17 @@ const Profile: React.FC = () => {
 
   if (!school) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
+      <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-600 mb-2">School Not Found</h1>
-          <p className="text-gray-500">The requested school could not be found.</p>
-          <button 
+          <h1 className="mb-2 text-2xl font-bold text-gray-600">
+            School Not Found
+          </h1>
+          <p className="text-gray-500">
+            The requested school could not be found.
+          </p>
+          <button
             onClick={() => router.back()}
-            className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="mt-4 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
           >
             Go Back
           </button>
@@ -124,10 +138,8 @@ const Profile: React.FC = () => {
               />
               <SchoolHeader school={school} />
               <SchoolAbout school={school} />
-              {school.metrics.length ? (
-                <SchoolStudentOutcomes school={school} />
-              ) : (
-                ""
+              {studentOutcomes.length > 0 && (
+                <SchoolStudentOutcomes stats={studentOutcomes} />
               )}
               <SchoolVolunteer school={school} />
               <SchoolDonation school={school} />


### PR DESCRIPTION
Closes #365 

This PR makes it so that the school statistics are always left-justified, even on small screens.

It also cleans up 'any' types.

Finally, there was a bug in the filtering for not displaying Student Outcomes. It was filtering based on whether there were any metrics. This has been fixed so that when there are metrics but no outcomes, we will no longer display the heading Student Outcomes.

Before:
<img width="539" height="501" alt="image" src="https://github.com/user-attachments/assets/23aad50a-d450-4caa-b98f-8f5f70e5b792" />

After:
<img width="540" height="505" alt="image" src="https://github.com/user-attachments/assets/0374f0dd-9cd8-4d6a-95da-3b321e044020" />

Before:
<img width="532" height="357" alt="image" src="https://github.com/user-attachments/assets/f3bebee7-72dc-4576-88da-2c4fd61dcac9" />

After:
<img width="543" height="279" alt="image" src="https://github.com/user-attachments/assets/eedf4e9a-a509-4703-a4d2-84bda7e29b5f" />
