### PR TITLE
offset for markers

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,643 +3,643 @@
       
   <url>
     <loc>https://www.supportsfschools.org/</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.335Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/map</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/about</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Balboa%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Burton%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Downtown%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Galileo%20Academy%20of%20Science%20%26%20Technology</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Ida%20B.%20Wells%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Independence%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=SF%20International%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=June%20Jordan%20School%20for%20Equity</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Lincoln%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Lowell%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Mission%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=John%20O'Connell%20Technical%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Ruth%20Asawa%20School%20of%20the%20Arts%20(SOTA)</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=The%20Academy</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Thurgood%20Marshall%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Wallenberg%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=George%20Washington%20High%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=A.P.%20Giannini%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Alamo%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Bessie%20Carmichael%20School%20PreK-8</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Alice%20Fong%20Yu%20Alternative%20School%20(K-8)</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Alvarado%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Aptos%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Argonne%20Elementary%20School%20-%20Extended%20Year</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=James%20Denman%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Bret%20Harte%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Bryant%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Buena%20Vista%20Horace%20Mann%20K-8%20Community%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=C%C3%A9sar%20Ch%C3%A1vez%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Dr.%20George%20Washington%20Carver%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Chinese%20Immersion%20School%20at%20De%20Avila%20%E4%B8%AD%E6%96%87%E6%B2%88%E6%B5%B8%E5%AD%B8%E6%A0%A1</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Civic%20Center%20Secondary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Claire%20Lilienthal%20Alternative%20School%20K-8</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Clarendon%20Alternative%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Cleveland%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Dr.%20Martin%20Luther%20King%2C%20Jr.%20Academic%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Commodore%20Sloat%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Daniel%20Webster%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Dianne%20Feinstein%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Dolores%20Huerta%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Dr.%20Charles%20R.%20Drew%20College%20Preparatory%20Academy</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Dr.%20William%20L.%20Cobb%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=E.R.%20Taylor%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Edwin%20and%20Anita%20Lee%20Newcomer%20School%20%E6%9D%8E%E5%AD%9F%E8%B3%A2%E4%BC%89%E5%84%B7%E6%96%B0%E7%A7%BB%E6%B0%91%E5%AD%B8%E6%A0%A1</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=El%20Dorado%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Hilltop%20%2B%20El%20Camino%20Alternativo%20Schools</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Everett%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Francis%20Scott%20Key%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Francisco%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Frank%20McCoppin%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Garfield%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=George%20Peabody%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=George%20R.%20Moscone%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Glen%20Park%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Gordon%20J.%20Lau%20Elementary%20School%20%E5%8A%89%E8%B2%B4%E6%98%8E%E5%B0%8F%E5%AD%B8</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Grattan%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Guadalupe%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Harvey%20Milk%20Civil%20Rights%20Academy</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Herbert%20Hoover%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Hillcrest%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=James%20Lick%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Jean%20Parker%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Jefferson%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=John%20Muir%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=John%20Yehall%20Chin%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Jose%20Ortega%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Junipero%20Serra%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Lafayette%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Lakeshore%20Alternative%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Lawton%20Alternative%20School%20(K-8)</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Leonard%20R.%20Flynn%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Longfellow%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Malcolm%20X%20Academy%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Marina%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Marshall%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=McKinley%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Miraloma%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Mission%20Education%20Center%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Monroe%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=New%20Traditions%20Creative%20Arts%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Paul%20Revere%20(PreK-8)%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Presidio%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Redding%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Robert%20Louis%20Stevenson%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Rooftop%20School%20TK-8</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Roosevelt%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Rosa%20Parks%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=San%20Francisco%20Community%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=San%20Francisco%20Public%20Montessori</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Sanchez%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Sheridan%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Sherman%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Spring%20Valley%20Science%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Starr%20King%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Sunnyside%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Sunset%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Sutro%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Tenderloin%20Community%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Ulloa%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Visitacion%20Valley%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Visitacion%20Valley%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=West%20Portal%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Willie%20L.%20Brown%20Jr.%20Middle%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 
   <url>
     <loc>https://www.supportsfschools.org/school?name=Yick%20Wo%20Alternative%20Elementary%20School</loc>
-    <lastmod>2026-02-06T01:01:28.921Z</lastmod>
+    <lastmod>2026-02-12T01:43:36.336Z</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -241,7 +241,7 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
     const geoJson = schoolsToGeoJSON(schools);
     const clusterIndex = new Supercluster<SchoolProperties, ClusterProperties>({
       radius: 50,
-      maxZoom: 13,
+      maxZoom: 14,
       minPoints: 2,
     });
     clusterIndex.load(geoJson.features);
@@ -307,7 +307,11 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
             className: "map-popup",
           }).setHTML(`<h3>${school.name}</h3>`);
           const schoolMarker = new mapboxgl.Marker(el)
-            .setLngLat([Number(school.longitude), Number(school.latitude)])
+            // .setLngLat([Number(school.longitude), Number(school.latitude)])
+            .setLngLat([
+              Number(school.longitude) + Math.random() * 0.00025, //offset in case two or more schools have the same coordinates
+              Number(school.latitude) + Math.random() * 0.00025, //offset in case two or more schools have the same coordinates
+            ])
             .setPopup(popup);
           // Don't add to map yet - updateClusters will handle visibility
           markersRef.current[school.name] = schoolMarker;

--- a/src/lib/clustering.ts
+++ b/src/lib/clustering.ts
@@ -17,7 +17,7 @@ export type ClusterPoint = GeoJSON.Feature<GeoJSON.Point, ClusterProperties>;
 export type MapPoint = SchoolPoint | ClusterPoint;
 
 export function schoolsToGeoJSON(
-  schools: School[]
+  schools: School[],
 ): GeoJSON.FeatureCollection<GeoJSON.Point, SchoolProperties> {
   return {
     type: "FeatureCollection",
@@ -34,21 +34,6 @@ export function schoolsToGeoJSON(
   };
 }
 
-export function isCluster(
-  point: MapPoint
-): point is ClusterPoint {
+export function isCluster(point: MapPoint): point is ClusterPoint {
   return (point.properties as ClusterProperties).cluster === true;
-}
-
-export function createClusterIndex(schools: School[]): Supercluster<SchoolProperties, ClusterProperties> {
-  const index = new Supercluster<SchoolProperties, ClusterProperties>({
-    radius: 50,     // Cluster radius in pixels
-    maxZoom: 14,    // Stop clustering at this zoom level
-    minPoints: 2,   // Minimum points to form a cluster
-  });
-
-  const geoJson = schoolsToGeoJSON(schools);
-  index.load(geoJson.features);
-
-  return index;
 }


### PR DESCRIPTION
I found an issue where one of the schools (Gordon J. Lau Elementary School 劉貴明小學) was not appearing on the map because it shares the same building and exact same coordinates as another school. To fix this and prevent similar problems in the future I added a small offset for each marker. now even if multiple schools are located in the same building, they will be displayed as separate markers (see pic)
Clusters handle schools correctly as well.

Additionally, I removed an unused function following Matt’s last review 
<img width="284" height="209" alt="Снимок экрана 2026-02-11 в 17 34 23" src="https://github.com/user-attachments/assets/c16e9e4a-fc69-4459-983b-96c021a4560c" />
