### PR TITLE
fix: improve ToggleButton accessibility (color contrast & aria-checked)

### DIFF
--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -45,10 +45,9 @@ const ToggleButton: React.FC<ToggleButtonProps> = ({
         onClick={toggleView}
         readOnly
         className="h-0 w-0 opacity-0"
-        aria-checked={isMapView}
         checked={!isMapView}
       />
-      <span className="slider absolute left-[3px] top-[2px] flex h-[calc(90%-1px)] w-[calc(50%-3px)] cursor-pointer items-center justify-center gap-1 rounded-md bg-[#3A86FF] text-white transition duration-300">
+      <span className="slider absolute left-[3px] top-[2px] flex h-[calc(90%-1px)] w-[calc(50%-3px)] cursor-pointer items-center justify-center gap-1 rounded-md bg-[#2563EB] text-white transition duration-300">
         <Image
           src={isMapView ? "/icons/location-icon.png" : "/icons/list-icon.png"}
           alt=""


### PR DESCRIPTION
tickets #452 #453 
Fixes two accessibility issues on the ToggleButton component flagged by axe DevTools:
- **Color contrast** — slider background changed from `#3A86FF` to `#2563EB` (contrast 3.48 → 5.16, passes WCAG AA)
- **ARIA attribute** — removed redundant `aria-checked` that conflicted with the native `checked` state