### PR TITLE
fix: improve school page link contrast (WCAG AA)

### DIFF
--- a/src/components/schoolPageComponents/SchoolAbout.tsx
+++ b/src/components/schoolPageComponents/SchoolAbout.tsx
@@ -14,7 +14,7 @@ const SchoolAbout: React.FC<{ school: School }> = ({ school }) => {
             {school.about_bp.map((bullet: string, i: number) => (
               <li
                 key={i}
-                className="ml-2"
+                className="ml-2 [&_a]:text-blue-600"
                 dangerouslySetInnerHTML={{ __html: bullet }}
               >
                 {/* {bullet} */}

--- a/src/components/schoolPageComponents/SchoolDonation.tsx
+++ b/src/components/schoolPageComponents/SchoolDonation.tsx
@@ -45,7 +45,7 @@ const SchoolDonation: React.FC<{ school: School }> = ({ school }) => {
                     href={school.donation_url}
                     target="_blank"
                     className={
-                      "w-fit rounded bg-blue-500 p-2 px-8 font-medium text-white"
+                      "w-fit rounded bg-blue-600 p-2 px-8 font-medium text-white"
                     }
                     onClick={() => posthog?.capture('main_donate_clicked', { school: school.name })}
                   >

--- a/src/components/schoolPageComponents/SchoolHeader.tsx
+++ b/src/components/schoolPageComponents/SchoolHeader.tsx
@@ -72,13 +72,13 @@ export default function SchoolHeader({ school }: Props) {
       <div className="flex gap-2">
         <a
           href="#volunteer"
-          className="rounded bg-blue-500 p-2 px-8 font-medium text-white"
+          className="rounded bg-blue-600 p-2 px-8 font-medium text-white"
         >
           Volunteer
         </a>
         <a
           href="#donate"
-          className="rounded border-2 border-blue-500 p-2 px-8 font-medium text-blue-500"
+          className="rounded border-2 border-blue-600 p-2 px-8 font-medium text-blue-600"
         >
           Donate
         </a>

--- a/src/components/schoolPageComponents/SchoolVolunteer.tsx
+++ b/src/components/schoolPageComponents/SchoolVolunteer.tsx
@@ -135,7 +135,7 @@ const SchoolVolunteer: React.FC<{ school: School }> = ({ school }) => {
                 href="https://sfedfund.org/become-a-volunteer/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mt-2 w-full rounded-lg bg-[#3A86FF] px-4 py-3 text-center font-semibold text-white"
+                className="mt-2 w-full rounded-lg bg-blue-600 px-4 py-3 text-center font-semibold text-white"
               >
                 Join the School Day Team
               </a>
@@ -149,7 +149,7 @@ const SchoolVolunteer: React.FC<{ school: School }> = ({ school }) => {
                 programs to PTA events, community projects, and more.
               </p>
               <button
-                className="mt-2 w-full rounded-lg bg-[#3A86FF] px-4 py-3 text-center font-semibold text-white"
+                className="mt-2 w-full rounded-lg bg-blue-600 px-4 py-3 text-center font-semibold text-white"
                 onClick={() => {
                   posthog?.capture?.("volunteer_form_clicked", {
                     school: school.name,


### PR DESCRIPTION
#399
## Summary
Fix insufficient color contrast on school page links and buttons flagged by WCAG 2.2 AA accessibility audit. 6 of 7 reported elements addressed in this PR (element #1 was already fixed by @seb-mejia in commit 6c39bf3).

## Changes
- **Volunteer button** (`SchoolHeader.tsx`): `bg-blue-500` → `bg-blue-600` (3.67:1 → 4.55:1)
- **Donate button (anchor)** (`SchoolHeader.tsx`): `border-blue-500 text-blue-500` → `border-blue-600 text-blue-600` (3.67:1 → 4.55:1)
- **Join the School Day Team** (`SchoolVolunteer.tsx`): `bg-[#3A86FF]` → `bg-blue-600` (3.48:1 → 4.55:1)
- **Join the After Hours Team** (`SchoolVolunteer.tsx`): `bg-[#3A86FF]` → `bg-blue-600` (3.48:1 → 4.55:1)
- **Donate button** (`SchoolDonation.tsx`): `bg-blue-500` → `bg-blue-600` (3.67:1 → 4.55:1)
- **Embedded links in school descriptions** (`SchoolAbout.tsx`): added `[&_a]:text-blue-600` to the `<li>` so links inside DB-rendered HTML use the accessible color via parent CSS specificity (3.67:1 → 4.55:1)



