### PR TITLE
feature: add Explore Schools link to navbar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -34,6 +34,7 @@ const Navbar = () => {
 
           {/* Links on desktop */}
           <div className="space-x-10 md:flex">
+            <Link href="/map">Explore Schools</Link>
             <Link href="/about">About Us</Link>
           </div>
         </div>


### PR DESCRIPTION
#479 

## Summary
Adds an "Explore Schools" link to the desktop navbar that navigates to the `/map` page. Placed before the existing "About Us" link, per ticket spec.

## Note on "How It Works" link
The ticket also requested a "How It Works" link to `/how-it-works`. That link is **NOT** in this PR because:
- The `/how-it-works` page not yet designed. I will add the navbar link in a follow-up PR with a placeholder page just in case we want to release "Explore Schools" first


## Changes
- `src/components/NavBar.tsx`: added one `<Link href="/map">Explore Schools</Link>` before the existing "About Us" link

## Test plan
- Verified link appears in the navbar on localhost
- Clicking "Explore Schools" navigates to `/map`
- "About Us" link still works
- No layout regressions
