### PR TITLE
[Feature]: zip code search map update

### DIFF
--- a/public/marker_zip_search.svg
+++ b/public/marker_zip_search.svg
@@ -2,13 +2,18 @@
   <title>marker_hover.svg</title>
   <rect fill="none" x="0" y="0" width="20" height="20" />
   <path
+    fill="#fff"
     transform="translate(2 2)"
     d="M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703
 	C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z"
-    fill="#3a86ff"
-    stroke="#ffffff"
+    style="stroke-linejoin:round;stroke-miterlimit:4;"
+    stroke="#fff"
     stroke-width="2"
-    stroke-linejoin="round"
-    stroke-linecap="round"
+  />
+  <path
+    fill="#3a86ff"
+    transform="translate(2 2)"
+    d="M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703
+	C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z"
   />
 </svg>

--- a/public/marker_zip_search.svg
+++ b/public/marker_zip_search.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" height="20" width="20">
+  <title>marker_hover.svg</title>
+  <rect fill="none" x="0" y="0" width="20" height="20" />
+  <path
+    transform="translate(2 2)"
+    d="M7.5,0C5.0676,0,2.2297,1.4865,2.2297,5.2703
+	C2.2297,7.8378,6.2838,13.5135,7.5,15c1.0811-1.4865,5.2703-7.027,5.2703-9.7297C12.7703,1.4865,9.9324,0,7.5,0z"
+    fill="#3a86ff"
+    stroke="#ffffff"
+    stroke-width="2"
+    stroke-linejoin="round"
+    stroke-linecap="round"
+  />
+</svg>

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -32,11 +32,22 @@ export default function MapPageClient(props: Props) {
   const [selectedSchoolTypes, setSelectedSchoolTypes] = useState<SchoolType[]>(
     [],
   );
+  const [searchZipcode, setSearchZipcode] = useState<string | null>(null);
   const [filteredSchools, setFilteredSchools] = useState(props.schools);
   const [priorityFilter, setPriorityFilter] = useState(false);
 
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
+  const ZIP_REGEX = /^\d{5}$/;
+
+  function updateSearchZipcode(searchZipcode: string) {
+    const trimmedZipcode = searchZipcode.trim();
+    if (ZIP_REGEX.test(trimmedZipcode)) {
+      setSearchZipcode(trimmedZipcode);
+    } else {
+      setSearchZipcode(null);
+    }
+  }
   useEffect(() => {
     const storedTypes = sessionStorage.getItem("selectedSchoolTypes");
     const storedPriority = sessionStorage.getItem("priorityFilter");
@@ -121,6 +132,8 @@ export default function MapPageClient(props: Props) {
   const handleSchoolSearch = async (searchTerm: string) => {
     posthog?.capture("searched_for_school", { searchTerm });
     const searchTermToLowerCase = searchTerm.toLowerCase();
+    updateSearchZipcode(searchTerm);
+
     return filteredSchools
       .filter(({ name, zipcode, neighborhood }) => {
         const nameToLowerCase = name.toLowerCase();
@@ -352,6 +365,7 @@ export default function MapPageClient(props: Props) {
                 <MapboxMap
                   setSelectedSchool={setSelectedSchool}
                   selectedSchool={selectedSchool}
+                  searchZipcode={searchZipcode}
                   schools={filteredSchools}
                 />
                 <div className="fixed bottom-0 left-0 right-0 z-10 m-4 rounded-2xl bg-white p-4 shadow-lg md:hidden">

--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -15,6 +15,7 @@ import { useMapContext } from "@/contexts/MapContext";
 import { SchoolType } from "@prisma/client";
 import FilterBySchoolType from "@/components/FilterBySchoolType";
 import { usePostHog } from "posthog-js/react";
+import { getValidSearchZipcode } from "@/utils/zipcode";
 
 type Props = {
   schools: SchoolMapPin[];
@@ -38,16 +39,6 @@ export default function MapPageClient(props: Props) {
 
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
-  const ZIP_REGEX = /^\d{5}$/;
-
-  function updateSearchZipcode(searchZipcode: string) {
-    const trimmedZipcode = searchZipcode.trim();
-    if (ZIP_REGEX.test(trimmedZipcode)) {
-      setSearchZipcode(trimmedZipcode);
-    } else {
-      setSearchZipcode(null);
-    }
-  }
   useEffect(() => {
     const storedTypes = sessionStorage.getItem("selectedSchoolTypes");
     const storedPriority = sessionStorage.getItem("priorityFilter");
@@ -132,7 +123,7 @@ export default function MapPageClient(props: Props) {
   const handleSchoolSearch = async (searchTerm: string) => {
     posthog?.capture("searched_for_school", { searchTerm });
     const searchTermToLowerCase = searchTerm.toLowerCase();
-    updateSearchZipcode(searchTerm);
+    setSearchZipcode(getValidSearchZipcode(searchTerm));
 
     return filteredSchools
       .filter(({ name, zipcode, neighborhood }) => {

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -498,7 +498,10 @@ const MapboxMap = ({ schools, searchZipcode }: MapboxMapProps) => {
         isZipHighlighted: zipcodeSchoolNames.has(schoolName),
       });
     });
-  }, [searchZipcode, selectedSchool, schools, mapLoaded]);
+
+    // Important: after changing marker classes, let clustering re-apply visibility.
+    updateClusters();
+  }, [searchZipcode, selectedSchool, schools, mapLoaded, updateClusters]);
 
   //add zip camera movement effect
   useEffect(() => {

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -13,10 +13,13 @@ import {
   schoolsToGeoJSON,
   isCluster,
 } from "@/lib/clustering";
+import { zip } from "fflate";
+import { mapTag } from "yaml/util";
 
 type MapboxMapProps = {
   setSelectedSchool: (school: SchoolMapPin | null) => void;
   selectedSchool: SchoolMapPin | null;
+  searchZipcode: string | null;
   schools: SchoolMapPin[];
 };
 
@@ -51,7 +54,7 @@ const isVisible = (marker: mapboxgl.Marker, map: mapboxgl.Map) => {
   return isInsideMap && isOnTop;
 };
 
-const MapboxMap = ({ schools }: MapboxMapProps) => {
+const MapboxMap = ({ schools, searchZipcode }: MapboxMapProps) => {
   const { selectedSchool, setSelectedSchool } = useMapContext();
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
@@ -75,17 +78,28 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
 
   const updateMarkerAppearance = (
     marker: mapboxgl.Marker,
-    isSelected: boolean,
+    options:{
+      isSelected: boolean,
+      isZipHighlighted?: boolean,
+    }
   ) => {
     const element = marker.getElement();
 
-    if (isSelected) {
+    if (options.isSelected) {
       element.className =
         "marker-selected mapboxgl-marker mapboxgl-marker-anchor-center";
-    } else {
-      element.className =
-        "marker mapboxgl-marker mapboxgl-marker-anchor-center";
+      return;
     }
+
+    if(options.isZipHighlighted){
+      element.className =
+        "marker marker-zipcode-highlight mapboxgl-marker mapboxgl-marker-anchor-center";
+      return;
+    }
+
+    element.className =
+      "marker mapboxgl-marker mapboxgl-marker-anchor-center";
+
   };
 
   // Function to update marker sizes based on zoom level
@@ -432,14 +446,14 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
     if (mapLoaded && mapRef.current) {
       // set all markers to default appearance
       Object.values(markersRef.current).forEach((marker) => {
-        updateMarkerAppearance(marker, false);
+        updateMarkerAppearance(marker, { isSelected: false });
       });
       if (selectedSchool) {
         const selectedMarker = markersRef.current[selectedSchool.name];
         if (selectedMarker) {
           // Ensure selected school marker is visible (not hidden by clustering)
           selectedMarker.addTo(mapRef.current);
-          updateMarkerAppearance(selectedMarker, true);
+          updateMarkerAppearance(selectedMarker, { isSelected: true });
           const lngLat = selectedMarker.getLngLat();
 
           if (!userHasInteracted.current) {
@@ -469,6 +483,59 @@ const MapboxMap = ({ schools }: MapboxMapProps) => {
       }
     }
   }, [selectedSchool, mapLoaded, flyToOptions, userHasInteracted]);
+
+  //update marker appearance when user searches a zipcode
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current) return;
+    const zipcodeSchoolNames = new Set(
+      searchZipcode
+        ? schools
+            .filter((school) => school.zipcode === searchZipcode)
+            .map((school) => school.name)
+        : [],
+    );
+    Object.entries(markersRef.current).forEach(([schoolName, marker]) => {
+      updateMarkerAppearance(marker, {
+        isSelected: selectedSchool?.name === schoolName,
+        isZipHighlighted: zipcodeSchoolNames.has(schoolName),
+      })
+    })
+  }, [searchZipcode, selectedSchool, schools, mapLoaded]);
+
+  //add zip camera movement effect
+  useEffect(() => {
+    if(!mapLoaded || !mapRef.current || !searchZipcode) return;
+
+    const matchingSchools = schools.filter((school) => school.zipcode === searchZipcode);
+    if(matchingSchools.length === 0) return;
+
+    if(matchingSchools.length === 1){
+      const school = matchingSchools[0];
+
+      if(!school.longitude || !school.latitude)return;
+      mapRef.current.flyTo({
+        center: [Number(school.longitude), Number(school.latitude)],
+        zoom: 13,
+        ...flyToOptions
+      });
+
+      return;
+    }
+    const bounds = new mapboxgl.LngLatBounds();
+    matchingSchools.forEach((school) => {
+      if(school.longitude && school.latitude){
+        bounds.extend([
+          Number(school.longitude),
+          Number(school.latitude)
+        ]);
+      }
+    });
+
+    mapRef.current.fitBounds(bounds, {
+      padding: 80,
+      maxZoom: 14,
+    });
+  }, [searchZipcode, schools, mapLoaded, flyToOptions]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "Escape") {

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -78,10 +78,10 @@ const MapboxMap = ({ schools, searchZipcode }: MapboxMapProps) => {
 
   const updateMarkerAppearance = (
     marker: mapboxgl.Marker,
-    options:{
-      isSelected: boolean,
-      isZipHighlighted?: boolean,
-    }
+    options: {
+      isSelected: boolean;
+      isZipHighlighted?: boolean;
+    },
   ) => {
     const element = marker.getElement();
 
@@ -91,15 +91,13 @@ const MapboxMap = ({ schools, searchZipcode }: MapboxMapProps) => {
       return;
     }
 
-    if(options.isZipHighlighted){
+    if (options.isZipHighlighted) {
       element.className =
         "marker marker-zipcode-highlight mapboxgl-marker mapboxgl-marker-anchor-center";
       return;
     }
 
-    element.className =
-      "marker mapboxgl-marker mapboxgl-marker-anchor-center";
-
+    element.className = "marker mapboxgl-marker mapboxgl-marker-anchor-center";
   };
 
   // Function to update marker sizes based on zoom level
@@ -498,36 +496,35 @@ const MapboxMap = ({ schools, searchZipcode }: MapboxMapProps) => {
       updateMarkerAppearance(marker, {
         isSelected: selectedSchool?.name === schoolName,
         isZipHighlighted: zipcodeSchoolNames.has(schoolName),
-      })
-    })
+      });
+    });
   }, [searchZipcode, selectedSchool, schools, mapLoaded]);
 
   //add zip camera movement effect
   useEffect(() => {
-    if(!mapLoaded || !mapRef.current || !searchZipcode) return;
+    if (!mapLoaded || !mapRef.current || !searchZipcode) return;
 
-    const matchingSchools = schools.filter((school) => school.zipcode === searchZipcode);
-    if(matchingSchools.length === 0) return;
+    const matchingSchools = schools.filter(
+      (school) => school.zipcode === searchZipcode,
+    );
+    if (matchingSchools.length === 0) return;
 
-    if(matchingSchools.length === 1){
+    if (matchingSchools.length === 1) {
       const school = matchingSchools[0];
 
-      if(!school.longitude || !school.latitude)return;
+      if (!school.longitude || !school.latitude) return;
       mapRef.current.flyTo({
         center: [Number(school.longitude), Number(school.latitude)],
         zoom: 13,
-        ...flyToOptions
+        ...flyToOptions,
       });
 
       return;
     }
     const bounds = new mapboxgl.LngLatBounds();
     matchingSchools.forEach((school) => {
-      if(school.longitude && school.latitude){
-        bounds.extend([
-          Number(school.longitude),
-          Number(school.latitude)
-        ]);
+      if (school.longitude && school.latitude) {
+        bounds.extend([Number(school.longitude), Number(school.latitude)]);
       }
     });
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -64,6 +64,16 @@ h6 * {
   z-index: 5;
 }
 
+.marker-zipcode-highlight {
+  background-image: url("/marker_zip_search.svg");
+  background-size: cover;
+  width: var(--marker-size, 20px); /* Default size at reference zoom */
+  height: var(--marker-size, 20px);
+  border-radius: 0;
+  cursor: pointer;
+  outline: none;
+}
+
 .golden-gate-marker {
   background-image: url("/GoldenGate.png");
   background-size: cover;

--- a/src/utils/zipcode.ts
+++ b/src/utils/zipcode.ts
@@ -1,0 +1,6 @@
+const ZIP_REGEX = /^\d{5}$/;
+
+export function getValidSearchZipcode(searchZipcode: string) {
+  const trimmedZipcode = searchZipcode.trim();
+  return ZIP_REGEX.test(trimmedZipcode) ? trimmedZipcode : null;
+}


### PR DESCRIPTION
When a user enters a valid 5-digit zip code in the school search, the map now:

- detects the zip search without changing the existing school list filtering behavior
- highlights visible individual school markers that match the zip code
- fits the map viewport to schools matching that zip code
- clears zip marker highlighting when the search input is cleared

This MVP intentionally keeps the existing school list and filter behavior unchanged.

## What changed

- Added local zip code search state in `MapPageClient`
- Added exact zip code detection using a small helper
- Passed the active zip search value into `MapboxMap`
- Added marker appearance handling for:
- Zip code highlighted school markers
- Added map camera movement to fit/fly to schools, matching the zip search

## Notes

This PR highlights matching **individual school markers** and fits the map to the matching schools.

Cluster marker highlighting is intentionally not included.

## Map zoomed in with school zip code search lightlight.  

<img width="1074" height="852" alt="Screenshot 2026-05-27 at 12 29 57 PM" src="https://github.com/user-attachments/assets/d3219f91-8f5f-4ec1-8084-f3c3b1786bc3" />
<img width="1058" height="844" alt="Screenshot 2026-05-27 at 12 30 04 PM" src="https://github.com/user-attachments/assets/af794f5f-d201-454f-a035-10e1743c8e54" />
