### PR TITLE
zipcode filter for the list view #491

### DIFF
--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -46,6 +46,7 @@ export default function MapPageClient(props: Props) {
   );
   const [filteredSchools, setFilteredSchools] = useState(props.schools);
   const [priorityFilter, setPriorityFilter] = useState(false);
+  const [searchFilteredSchools, setSearchFilteredSchools] = useState<SchoolMapPin[] | null>(null);
 
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
@@ -133,21 +134,29 @@ export default function MapPageClient(props: Props) {
   const handleSchoolSearch = async (searchTerm: string) => {
     posthog?.capture("searched_for_school", { searchTerm });
     const searchTermToLowerCase = searchTerm.toLowerCase();
-    return filteredSchools
-      .filter(({ name, zipcode, neighborhood }) => {
-        const nameToLowerCase = name.toLowerCase();
-        const neighborhoodToLowerCase = neighborhood?.toLowerCase();
-        return (
-          nameToLowerCase.includes(searchTermToLowerCase) ||
-          zipcode?.includes(searchTermToLowerCase) ||
-          neighborhoodToLowerCase?.includes(searchTermToLowerCase)
-        );
-      })
-      .map((school) => ({
-        label: school.name,
-        value: school.name,
-        item: school,
-      }));
+
+    if (!searchTerm.trim()) {
+      setSearchFilteredSchools(null);
+      return [];
+    }
+
+    const results = filteredSchools.filter(({ name, zipcode, neighborhood }) => {
+      const nameToLowerCase = name.toLowerCase();
+      const neighborhoodToLowerCase = neighborhood?.toLowerCase();
+      return (
+        nameToLowerCase.includes(searchTermToLowerCase) ||
+        zipcode?.includes(searchTermToLowerCase) ||
+        neighborhoodToLowerCase?.includes(searchTermToLowerCase)
+      );
+    });
+
+    setSearchFilteredSchools(results);
+
+    return results.map((school) => ({
+      label: school.name,
+      value: school.name,
+      item: school,
+    }));
   };
 
   const itemSelect = (selection: DropdownItem<SchoolMapPin>) => {
@@ -189,6 +198,7 @@ export default function MapPageClient(props: Props) {
             <SearchBar
               onItemSelect={itemSelect}
               onSearch={handleSchoolSearch}
+              showDropdown={isMapView}
             />
           </div>
 
@@ -343,6 +353,7 @@ export default function MapPageClient(props: Props) {
                   <SearchBar
                     onItemSelect={itemSelect}
                     onSearch={handleSchoolSearch}
+                    showDropdown={isMapView}
                   />
                 </div>
                 <div className="w-1/3">
@@ -379,7 +390,7 @@ export default function MapPageClient(props: Props) {
               <MapList
                 setSelectedSchool={setSelectedSchool}
                 selectedSchool={selectedSchool}
-                schools={filteredSchools}
+                schools={searchFilteredSchools ?? filteredSchools}
                 onModalOpen={openModal}
               />
             )}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -7,11 +7,13 @@ import type { DropdownItem } from "@/types/school";
 interface SearchBarProps<DropdownItemType> {
   onItemSelect: (item: DropdownItem<DropdownItemType>) => void;
   onSearch: (searchTerm: string) => Promise<DropdownItem<DropdownItemType>[]>;
+  showDropdown?: boolean;
 }
 
 export default function SearchBar<DropdownItemType = any>({
   onItemSelect,
   onSearch,
+  showDropdown = true,
 }: SearchBarProps<DropdownItemType>): React.JSX.Element {
   const [searchTerm, setSearchTerm] = useState("");
   const [dropdownItems, setDropdownItems] = useState<
@@ -85,7 +87,7 @@ export default function SearchBar<DropdownItemType = any>({
         }}
         onKeyDown={handleKeyDown}
       />
-      {dropdownItems.length > 0 && (
+      {showDropdown && dropdownItems.length > 0 && (
         <Dropdown
           items={dropdownItems}
           onItemSelect={handleItemSelect}


### PR DESCRIPTION
 feat: filter list view by search term

  Summary

  - When a user types in the search bar while in list view, the list is filtered in real time to show only schools matching the search term (by name, zip code, or neighborhood)
  - The dropdown is hidden in list view — results appear directly in the list instead
  - Behavior in map view is unchanged: dropdown still appears as before

  Test plan

  - Switch to list view, type a zip code (e.g. 94110) — list should narrow to matching schools
  - Type a partial zip (e.g. 9411) — list should show all schools whose zip contains those digits
  - Type a school name — list should filter to matching schools
  - Clear the search bar — full list should restore
  - Switch to map view — dropdown should still appear as normal
  - Confirm no regression on school type / priority filters combined with search