### PR TITLE
[ticket #535] fix selected pins that were duplicated

### DIFF
--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -443,6 +443,11 @@ const MapboxMap = ({ schools, selectedZipcode = null }: MapboxMapProps) => {
 
       // Create all school markers (they'll be shown/hidden by updateClusters)
       schools.forEach((school) => {
+        // Remove any previously tracked marker for this school (guards against
+        // double-invocation in React Strict Mode where map.on("load") can fire
+        // from a prior map instance after cleanup, adding orphaned elements)
+        markersRef.current[school.name]?.remove();
+
         // create an HTML element for each school
         const el = document.createElement("button");
         el.className = "marker";


### PR DESCRIPTION
 Summary

  - Fixed a bug where a selected school (yellow pin) appeared twice on the map at max zoom when a zipcode search was active
  - The root cause: React Strict Mode double-invokes useEffect in development. The map.on("load") callback from the first (cleaned-up) map instance could still fire after the second map was initialized, causing a first batch of markers to be
   added to the new map. When the second load callback fired, a second batch was created and markersRef was overwritten — leaving the first batch orphaned in the DOM, never getting their class reset on selection changes
  - Fix: before creating a marker for a school, call .remove() on any previously tracked marker for that name, evicting orphaned elements from the map before they can accumulate

 Test plan

  - Search for a zipcode, select a school — confirm only one yellow pin appears at all zoom levels including max zoom (15)
  - Select a school without zipcode search — confirm single yellow pin at all zoom levels