### PR TITLE
[ticket #536] fix map height and padding-top

### DIFF
--- a/src/components/MapListCard.tsx
+++ b/src/components/MapListCard.tsx
@@ -49,7 +49,11 @@ const MapListCard = ({
   const learnMoreRef = useRef<HTMLAnchorElement>(null);
 
   const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
-    if (e.propertyName === "max-height" && isExpanded) {
+    if (
+      e.propertyName === "max-height" &&
+      isExpanded &&
+      e.currentTarget === e.target
+    ) {
       cardRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
     }
   };
@@ -80,14 +84,11 @@ const MapListCard = ({
   return (
     <div
       ref={cardRef}
-      className={`grid cursor-pointer grid-cols-10 overflow-hidden rounded-lg border-2 bg-white ${
-        isExpanded ? "max-h-[300px]" : "max-h-[104px]"
-      } transition-max-height relative duration-[700ms]`}
+      className="relative grid cursor-pointer grid-cols-10 overflow-hidden rounded-lg border-2 bg-white"
       onClick={onClick}
-      onTransitionEnd={handleTransitionEnd}
     >
       <div className="col-span-6 justify-center overflow-hidden px-4 pb-4 transition-all ease-in-out md:col-span-7">
-        <div className="flex h-[104px] flex-col justify-center">
+        <div className="flex min-h-[104px] flex-col justify-start py-2">
           {school.priority && (
             <button
               onClick={(e) => {
@@ -101,13 +102,18 @@ const MapListCard = ({
           )}
           <div className="flex grid-cols-6 flex-col md:grid md:items-center md:gap-2">
             <div className="col-span-4 font-bold md:text-xl">{name}</div>
-            <div className="col-span-2 text-gray-600 max-md:text-sm">
+            <div className="col-span-2 break-words text-gray-600 max-md:text-sm">
               {neighborhood}
             </div>
           </div>
         </div>
 
-        <div className="flex flex-col gap-5 max-md:text-sm">
+        <div
+          className={`transition-max-height overflow-hidden duration-[700ms] ${
+            isExpanded ? "max-h-[200px]" : "max-h-0"
+          } flex flex-col gap-5 max-md:text-sm`}
+          onTransitionEnd={handleTransitionEnd}
+        >
           <VolunteerList school={school} fullCard={false} />
           <Link
             ref={learnMoreRef}
@@ -123,11 +129,7 @@ const MapListCard = ({
           </Link>
         </div>
       </div>
-      <div
-        className={`transition-max-height relative col-span-4 rounded-r-lg duration-[700ms] md:col-span-3 ${
-          isExpanded ? "max-h-[300px]" : "max-h-[104px]"
-        }`}
-      >
+      <div className="relative col-span-4 min-h-[104px] rounded-r-lg md:col-span-3">
         <Image
           src={`/school-images/full/${stub}.webp`}
           placeholder="blur"


### PR DESCRIPTION
⏺ Here's what changed in MapListCard and why:
                                                                                                                                                                                                                          
  1. Removed fixed max-h from the outer card
  Before: the whole card was clipped to max-h-[104px] (collapsed) / max-h-[300px] (expanded).
  After: the outer card has no fixed height — it sizes naturally to its content.

  2. Changed h-[104px] → min-h-[104px] with justify-start py-2 on the always-visible section
  Before: the name/neighborhood/priority section was forced to exactly 104px, which clipped long names.
  After: it's at least 104px but grows if the name wraps or the priority banner is present. justify-start with consistent padding replaces justify-center so the top padding is the same on every card.

  3. Moved the expand/collapse animation to the expandable section only
  Before: the animation was on the outer card (max-h toggling the whole thing).
  After: only the volunteer list + Learn More button have the max-h-0 → max-h-[200px] transition. This section is hidden when collapsed and animates open when expanded, while the name/priority section above it is always fully visible.

  4. Added min-h-[104px] to the image column
  The school image uses fill which requires its parent to have a defined height. Since we removed the outer card's fixed height, the image column needs its own minimum height to render correctly.

