### PR TITLE
[ticket #539] selected school zoom + map reset when input is empty

### DIFF
--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -58,6 +58,8 @@ export default function MapPageClient(props: Props) {
   const [searchFilteredSchools, setSearchFilteredSchools] = useState<
     SchoolMapPin[] | null
   >(null);
+  const [zoomToSchool, setZoomToSchool] = useState<SchoolMapPin | null>(null);
+  const [resetMapView, setResetMapView] = useState(0);
 
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [isMobileLikeLayout, setIsMobileLikeLayout] = useState(false);
@@ -204,6 +206,7 @@ export default function MapPageClient(props: Props) {
     });
     setSelectedZipcode(undefined);
     setSelectedSchool(selection.item);
+    setZoomToSchool(selection.item);
   };
 
   const handleSearchSubmit = (searchTerm: string) => {
@@ -211,6 +214,14 @@ export default function MapPageClient(props: Props) {
     setSelectedZipcode(
       ZIPCODE_PATTERN.test(trimmedSearchTerm) ? trimmedSearchTerm : undefined,
     );
+  };
+
+  const handleSearchClear = () => {
+    setSelectedSchool(null);
+    setSelectedZipcode(undefined);
+    setSearchFilteredSchools(null);
+    setZoomToSchool(null);
+    setResetMapView((n) => n + 1);
   };
 
   const SelectedSchoolCard = (props: {
@@ -257,6 +268,7 @@ export default function MapPageClient(props: Props) {
               onItemSelect={itemSelect}
               onSearch={handleSchoolSearch}
               onSearchSubmit={isMapView ? handleSearchSubmit : undefined}
+              onSearchClear={handleSearchClear}
               showDropdown={isMapView}
               selectedZipcode={selectedZipcode}
               setSelectedZipcode={setSelectedZipcode}
@@ -376,6 +388,7 @@ export default function MapPageClient(props: Props) {
                     onItemSelect={itemSelect}
                     onSearch={handleSchoolSearch}
                     onSearchSubmit={handleSearchSubmit}
+                    onSearchClear={handleSearchClear}
                     selectedZipcode={selectedZipcode}
                     setSelectedZipcode={setSelectedZipcode}
                   />
@@ -410,6 +423,8 @@ export default function MapPageClient(props: Props) {
                 selectedSchool={selectedSchool}
                 schools={schoolsForDisplay}
                 selectedZipcode={selectedZipcode}
+                zoomToSchool={zoomToSchool}
+                resetView={resetMapView}
               />
             </div>
           </div>
@@ -456,6 +471,8 @@ export default function MapPageClient(props: Props) {
                   selectedSchool={selectedSchool}
                   schools={schoolsForDisplay}
                   selectedZipcode={selectedZipcode}
+                  zoomToSchool={zoomToSchool}
+                  resetView={resetMapView}
                 />
                 <div className="fixed bottom-0 left-0 right-0 z-10 m-4 rounded-2xl bg-white p-4 shadow-lg">
                   <div className="align-center flex flex-col items-center gap-0 text-center">

--- a/src/components/MapboxMap.tsx
+++ b/src/components/MapboxMap.tsx
@@ -26,6 +26,8 @@ type MapboxMapProps = {
   selectedSchool: SchoolMapPin | null;
   schools: SchoolMapPin[];
   selectedZipcode?: string | null;
+  zoomToSchool?: SchoolMapPin | null;
+  resetView?: number;
 };
 
 type ZctaFeature = Feature<Polygon | MultiPolygon, { zipcode: string }>;
@@ -102,7 +104,7 @@ const isVisible = (marker: mapboxgl.Marker, map: mapboxgl.Map) => {
   return isInsideMap && isOnTop;
 };
 
-const MapboxMap = ({ schools, selectedZipcode = null }: MapboxMapProps) => {
+const MapboxMap = ({ schools, selectedZipcode = null, zoomToSchool = null, resetView = 0 }: MapboxMapProps) => {
   const { selectedSchool, setSelectedSchool } = useMapContext();
   const mapContainer = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
@@ -120,6 +122,8 @@ const MapboxMap = ({ schools, selectedZipcode = null }: MapboxMapProps) => {
     selectedSchool?.name ?? null,
   );
   const hasSkippedInitialPersistedRecenterRef = useRef(false);
+  const lastAppliedResetViewRef = useRef(0);
+  const lastAppliedZoomToSchoolRef = useRef<string | null>(null);
   const posthog = usePostHog();
   const flyToOptions = useMemo(
     () => ({
@@ -655,6 +659,35 @@ const MapboxMap = ({ schools, selectedZipcode = null }: MapboxMapProps) => {
       }
     }
   }, [selectedSchool, mapLoaded, flyToOptions, userHasInteracted]);
+
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current) return;
+    if (!zoomToSchool) {
+      lastAppliedZoomToSchoolRef.current = null;
+      return;
+    }
+    if (zoomToSchool.stub === lastAppliedZoomToSchoolRef.current) return;
+    lastAppliedZoomToSchoolRef.current = zoomToSchool.stub;
+    mapRef.current.flyTo({
+      center: [parseFloat(zoomToSchool.longitude), parseFloat(zoomToSchool.latitude)],
+      zoom: 15,
+      ...flyToOptions,
+    });
+  }, [zoomToSchool, mapLoaded, flyToOptions]);
+
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current || resetView === 0) return;
+    if (resetView === lastAppliedResetViewRef.current) return;
+    lastAppliedResetViewRef.current = resetView;
+    const vw = mapRef.current.getContainer().clientWidth;
+    const zoom =
+      vw < 640 ? 10.7 : vw < 1024 ? 10.9 : vw < 1440 ? 11.1 : vw < 1920 ? 11.35 : 11.5;
+    mapRef.current.flyTo({
+      center: [-122.435, 37.762],
+      zoom,
+      ...flyToOptions,
+    });
+  }, [resetView, mapLoaded, flyToOptions]);
 
   useEffect(() => {
     const map = mapRef.current;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -8,6 +8,7 @@ interface SearchBarProps<DropdownItemType> {
   onItemSelect: (item: DropdownItem<DropdownItemType>) => void;
   onSearch: (searchTerm: string) => Promise<DropdownItem<DropdownItemType>[]>;
   onSearchSubmit?: (searchTerm: string) => void;
+  onSearchClear?: () => void;
   showDropdown?: boolean;
   selectedZipcode?: string;
   setSelectedZipcode?: (zipcode: string) => void;
@@ -17,6 +18,7 @@ export default function SearchBar<DropdownItemType = unknown>({
   onItemSelect,
   onSearch,
   onSearchSubmit,
+  onSearchClear,
   showDropdown = true,
   selectedZipcode,
   setSelectedZipcode,
@@ -33,6 +35,9 @@ export default function SearchBar<DropdownItemType = unknown>({
     const userInput = e.target.value;
     setSearchTerm(userInput);
     setSelectedZipcode?.(userInput);
+    if (!userInput) {
+      onSearchClear?.();
+    }
     const searchResults = await onSearch(userInput);
     setDropdownItems(searchResults);
     setShowNoResults(userInput.trim().length > 0 && searchResults.length === 0);
@@ -56,11 +61,9 @@ export default function SearchBar<DropdownItemType = unknown>({
 
   const handleClear = () => {
     setSearchTerm("");
-    setSelectedZipcode?.("");
     setDropdownItems([]);
     setShowNoResults(false);
-    onSearch("");
-    inputRef.current?.focus();
+    onSearchClear?.();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Summary
  
  - When a school is selected from the search dropdown, the map now flies and zooms to that school's pin (zoom level 15)
  - When the search bar is cleared (X button or backspacing to empty), the map resets to the default SF overview, all school pins are restored, and the list returns to the full school list

  How it works

  Zoom to selected school (Feature 1)
  A new zoomToSchool state is set in itemSelect when a school is chosen from the dropdown. MapboxMap receives this as a prop and flies to the school's coordinates at zoom 15. A ref (lastAppliedZoomToSchoolRef) ensures the zoom only fires
  once per selection — not on every map re-render triggered by typing in the search bar.

  Reset on clear (Feature 2)
  A new onSearchClear callback on SearchBar fires when the input becomes empty (X button or backspace). It resets selectedSchool, selectedZipcode, and searchFilteredSchools to their defaults, and increments a resetMapView counter. MapboxMap
  watches this counter and flies back to the SF center at the appropriate zoom level. A ref (lastAppliedResetViewRef) ensures this only fires once per clear, not on subsequent map re-renders.