### PR TITLE
New StepBox component

### DIFF
--- a/src/app/preview/step-box/page.tsx
+++ b/src/app/preview/step-box/page.tsx
@@ -22,23 +22,11 @@ export default function StepBoxPreviewPage() {
 
       <StepBox
         stepNumber={2}
-        title="Explore Schools"
-        description="Browse schools on the map and find one that's right for you."
-        button={
-          <Link
-            href="/map"
-            className="bg-brand-sunglow text-brand-navy inline-flex items-center gap-[10px] rounded-lg px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] transition-opacity hover:opacity-90"
-          >
-            Explore Schools
-          </Link>
-        }
+        title="We Match You with Opportunities"
+        description="Based on your responses we will connect you with our recommendation from our growing list of partner organizations, to set up a volunteer placement:"
       />
 
-      <StepBox
-        stepNumber={3}
-        title="No button variant"
-        description="This step has no CTA button."
-      />
+      <StepBox stepNumber={3} title="Partner Organizations" />
     </main>
   );
 }

--- a/src/app/preview/step-box/page.tsx
+++ b/src/app/preview/step-box/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import StepBox from "@/components/HowItWorks/StepBox";
+import StepBoxMobile from "@/components/HowItWorks/StepBoxMobile";
 
 export default function StepBoxPreviewPage() {
   return (
@@ -27,6 +28,34 @@ export default function StepBoxPreviewPage() {
       />
 
       <StepBox stepNumber={3} title="Partner Organizations" />
+
+      <h2 className="pt-6 font-fredoka text-2xl font-semibold">
+        Mobile Variant
+      </h2>
+
+      <div className="flex w-[392px] flex-col gap-4 px-[15px] py-[11px]">
+        <StepBoxMobile
+          stepNumber={1}
+          title="Take the Volunteer Survey"
+          description="You can take our Volunteer Survey to find the best match for your interests. Or Explore Schools on your own."
+          button={
+            <Link
+              href="/survey"
+              className="bg-brand-azure inline-flex w-full items-center justify-center gap-[10px] rounded-lg px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] text-white transition-opacity hover:opacity-90"
+            >
+              Take the Volunteer Survey
+            </Link>
+          }
+        />
+
+        <StepBoxMobile
+          stepNumber={2}
+          title="We Match You with Opportunities"
+          description="Based on your responses we will connect you with our recommendation from our growing list of partner organizations, to set up a volunteer placement:"
+        />
+
+        <StepBoxMobile stepNumber={3} title="Partner Organizations" />
+      </div>
     </main>
   );
 }

--- a/src/app/preview/step-box/page.tsx
+++ b/src/app/preview/step-box/page.tsx
@@ -14,7 +14,7 @@ export default function StepBoxPreviewPage() {
         button={
           <Link
             href="/survey"
-            className="bg-brand-sunglow text-brand-navy inline-flex items-center gap-[10px] rounded-lg px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] transition-opacity hover:opacity-90"
+            className="inline-flex items-center gap-[10px] rounded-lg bg-brand-sunglow px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] text-brand-navy transition-opacity hover:opacity-90"
           >
             Take the Volunteer Survey
           </Link>
@@ -33,7 +33,7 @@ export default function StepBoxPreviewPage() {
         Mobile Variant
       </h2>
 
-      <div className="flex w-[392px] flex-col gap-4 px-[15px] py-[11px]">
+      <div className="flex w-[392px] flex-col gap-4 bg-white px-[15px] py-[11px]">
         <StepBoxMobile
           stepNumber={1}
           title="Take the Volunteer Survey"
@@ -41,7 +41,7 @@ export default function StepBoxPreviewPage() {
           button={
             <Link
               href="/survey"
-              className="bg-brand-azure inline-flex w-full items-center justify-center gap-[10px] rounded-lg px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] text-white transition-opacity hover:opacity-90"
+              className="inline-flex w-full items-center justify-center gap-[10px] rounded-lg bg-brand-azure px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] text-white transition-opacity hover:opacity-90"
             >
               Take the Volunteer Survey
             </Link>

--- a/src/app/preview/step-box/page.tsx
+++ b/src/app/preview/step-box/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import StepBox from "@/components/HowItWorks/StepBox";
+
+export default function StepBoxPreviewPage() {
+  return (
+    <main className="mx-auto max-w-xl space-y-6 bg-[#E9FAFC] p-10">
+      <h1 className="font-fredoka text-3xl font-semibold">StepBox Preview</h1>
+
+      <StepBox
+        stepNumber={1}
+        title="Take the Volunteer Survey"
+        description="You can take our Volunteer Survey to find the best match for your interests. Or Explore Schools on your own."
+        button={
+          <Link
+            href="/survey"
+            className="bg-brand-sunglow text-brand-navy inline-flex items-center gap-[10px] rounded-lg px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] transition-opacity hover:opacity-90"
+          >
+            Take the Volunteer Survey
+          </Link>
+        }
+      />
+
+      <StepBox
+        stepNumber={2}
+        title="Explore Schools"
+        description="Browse schools on the map and find one that's right for you."
+        button={
+          <Link
+            href="/map"
+            className="bg-brand-sunglow text-brand-navy inline-flex items-center gap-[10px] rounded-lg px-4 py-3 font-lato text-base font-bold leading-7 tracking-[0.005em] transition-opacity hover:opacity-90"
+          >
+            Explore Schools
+          </Link>
+        }
+      />
+
+      <StepBox
+        stepNumber={3}
+        title="No button variant"
+        description="This step has no CTA button."
+      />
+    </main>
+  );
+}

--- a/src/components/HowItWorks/StepBox.tsx
+++ b/src/components/HowItWorks/StepBox.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+type StepBoxProps = {
+  stepNumber: number;
+  title: string;
+  description?: string;
+  button?: ReactNode;
+};
+
+const StepBox = ({ stepNumber, title, description, button }: StepBoxProps) => {
+  return (
+    <div className="flex items-start gap-6">
+      <div className="bg-brand-sunglow flex h-12 w-12 shrink-0 items-center justify-center rounded-full p-4">
+        <span className="text-brand-navy font-fredoka text-[36px] font-semibold leading-none tracking-[0.02em]">
+          {stepNumber}
+        </span>
+      </div>
+
+      <div className="mt-2 flex flex-1 flex-col gap-6 rounded-2xl">
+        <h3 className="text-brand-azure font-fredoka text-[32px] font-medium leading-none tracking-[0.02em]">
+          {title}
+        </h3>
+        {description && description.length > 0 && (
+          <p className="text-brand-raisin font-lato text-xl font-normal leading-8 tracking-[0.02em]">
+            {description}
+          </p>
+        )}
+        <div className="w-fit">{button}</div>
+      </div>
+    </div>
+  );
+};
+
+export default StepBox;

--- a/src/components/HowItWorks/StepBoxMobile.tsx
+++ b/src/components/HowItWorks/StepBoxMobile.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+type StepBoxMobileProps = {
+  stepNumber: number;
+  title: string;
+  description?: string;
+  button?: ReactNode;
+};
+
+const StepBoxMobile = ({
+  stepNumber,
+  title,
+  description,
+  button,
+}: StepBoxMobileProps) => {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-[25px] bg-white p-5">
+      <div className="bg-brand-sunglow flex h-9 w-9 shrink-0 items-center justify-center gap-[10px] rounded-full p-[10px]">
+        <span className="text-brand-navy font-fredoka text-[24px] font-semibold leading-none tracking-[0.02em]">
+          {stepNumber}
+        </span>
+      </div>
+
+      <div className="flex w-full flex-col gap-6">
+        <h3 className="text-brand-azure text-center font-fredoka text-[24px] font-medium leading-none">
+          {title}
+        </h3>
+        {description && description.length > 0 && (
+          <p className="text-brand-raisin font-lato text-base font-normal leading-6 tracking-[0.02em]">
+            {description}
+          </p>
+        )}
+        {button && <div className="w-full">{button}</div>}
+      </div>
+    </div>
+  );
+};
+
+export default StepBoxMobile;

--- a/src/components/HowItWorks/StepBoxMobile.tsx
+++ b/src/components/HowItWorks/StepBoxMobile.tsx
@@ -14,19 +14,19 @@ const StepBoxMobile = ({
   button,
 }: StepBoxMobileProps) => {
   return (
-    <div className="flex flex-col items-center gap-4 rounded-[25px] bg-white p-5">
-      <div className="bg-brand-sunglow flex h-9 w-9 shrink-0 items-center justify-center gap-[10px] rounded-full p-[10px]">
-        <span className="text-brand-navy font-fredoka text-[24px] font-semibold leading-none tracking-[0.02em]">
+    <div className="flex flex-col items-center gap-4 rounded-[25px] bg-brand-sunglow/30 p-5">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center gap-[10px] rounded-full bg-brand-sunglow p-[10px]">
+        <span className="font-fredoka text-[24px] font-semibold leading-none tracking-[0.02em] text-brand-navy">
           {stepNumber}
         </span>
       </div>
 
       <div className="flex w-full flex-col gap-6">
-        <h3 className="text-brand-azure text-center font-fredoka text-[24px] font-medium leading-none">
+        <h3 className="text-center font-fredoka text-[24px] font-medium leading-none text-brand-azure">
           {title}
         </h3>
         {description && description.length > 0 && (
-          <p className="text-brand-raisin font-lato text-base font-normal leading-6 tracking-[0.02em]">
+          <p className="font-lato text-base font-normal leading-6 tracking-[0.02em] text-brand-raisin">
             {description}
           </p>
         )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,14 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        brand: {
+          sunglow: "#FFC627",
+          azure: "#3A86FF",
+          raisin: "#272728",
+          navy: "#0B1F44",
+        },
+      },
       fontFamily: {
         fredoka: ["var(--font-fredoka)", "sans-serif"],
         lato: ["var(--font-lato)", "sans-serif"],


### PR DESCRIPTION
This PR adds what I am calling the "StepBox" component.
<img width="589" height="267" alt="image" src="https://github.com/user-attachments/assets/e4d3d623-a114-4795-abf8-6082a00cb6be" />
<img width="388" height="309" alt="image" src="https://github.com/user-attachments/assets/59f21dbd-3c66-4e2c-bb29-d459fca97a0d" />
I have temporarily added a preview route to allow you to manually see what it looks like, I'll remove it before merging:
https://support-sfusd-git-feature-how-it-c49f76-supportsfusds-projects.vercel.app/preview/step-box

This component will be used in the desktop versions of the How It Works page.

To use them in practice, we can use Tailwind-style media queries:
```
  {/* Desktop only */}
  <div className="hidden md:flex flex-col gap-6">
    <StepBox stepNumber={2} title="We Match You" />
  </div>

  {/* Mobile only */}
  <div className="flex flex-col gap-4 md:hidden">
    <StepBoxMobile stepNumber={2} title="We Match You" />
</div>
```