### PR TITLE
Add Opportunity model with migration and seed data

### DIFF
--- a/prisma/migrations/20260901062555_add_opportunity/migration.sql
+++ b/prisma/migrations/20260901062555_add_opportunity/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Opportunity" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "organization" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "start_date" DATE,
+    "end_date" DATE,
+    "time_text" TEXT,
+    "is_year_round" BOOLEAN NOT NULL DEFAULT false,
+    "location" TEXT NOT NULL,
+    "school_stub" TEXT,
+    "is_test" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "Opportunity_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Opportunity" ADD CONSTRAINT "Opportunity_school_stub_fkey" FOREIGN KEY ("school_stub") REFERENCES "School"("stub") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/opportunities.json
+++ b/prisma/opportunities.json
@@ -1,0 +1,38 @@
+[
+  {
+    "organization": "SF Ed Fund",
+    "title": "Back to School Setup Day",
+    "description": "Help set up teacher's classrooms!",
+    "start_date": "2026-08-14",
+    "end_date": null,
+    "time_text": "9AM-4PM",
+    "is_year_round": false,
+    "location": "City-wide",
+    "school_stub": null,
+    "is_test": true
+  },
+  {
+    "organization": "Mission Bit",
+    "title": "Coding project volunteer",
+    "description": "Help students with summer coding projects!",
+    "start_date": "2026-06-23",
+    "end_date": "2026-07-30",
+    "time_text": "4-6PM",
+    "is_year_round": false,
+    "location": "329 Bryant St. SF",
+    "school_stub": null,
+    "is_test": true
+  },
+  {
+    "organization": "Good Neighbor Lab",
+    "title": "Cantonese translation support",
+    "description": "Translate elementary school communication into Cantonese",
+    "start_date": null,
+    "end_date": null,
+    "time_text": null,
+    "is_year_round": true,
+    "location": "Remote",
+    "school_stub": null,
+    "is_test": true
+  }
+]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model School {
   website_url        String?
   metrics            Metric[]
   programs           Program[]
+  opportunities      Opportunity[]
 }
 
 model Metric {
@@ -57,6 +58,21 @@ model Program {
   url      String?
   img      String?
   category ProgramCategory
+}
+
+model Opportunity {
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  organization  String
+  title         String
+  description   String
+  start_date    DateTime? @db.Date
+  end_date      DateTime? @db.Date
+  time_text     String?
+  is_year_round Boolean   @default(false)
+  location      String
+  school_stub   String?
+  school        School?   @relation(fields: [school_stub], references: [stub])
+  is_test       Boolean   @default(false)
 }
 
 enum MetricCategory {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -95,6 +95,12 @@ async function main() {
     }),
   );
   for (const opportunity of opportunities) {
+    opportunity.start_date = opportunity.start_date
+      ? new Date(opportunity.start_date)
+      : null;
+    opportunity.end_date = opportunity.end_date
+      ? new Date(opportunity.end_date)
+      : null;
     await prisma.opportunity.create({
       data: opportunity,
     });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -88,6 +88,17 @@ async function main() {
       data: addPrismaCreateStatements(school),
     });
   }
+
+  const opportunities = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "opportunities.json"), {
+      encoding: "utf-8",
+    }),
+  );
+  for (const opportunity of opportunities) {
+    await prisma.opportunity.create({
+      data: opportunity,
+    });
+  }
 }
 
 main()


### PR DESCRIPTION
Models volunteer/support opportunity cards (org, title, description, scheduling, location) with an optional School relation and an is_test flag for demo seed rows.